### PR TITLE
fdp_id masked via GLOBALS, rename to fdp_gid to match CDP module

### DIFF
--- a/lib/SNMP/Info/FDP.pm
+++ b/lib/SNMP/Info/FDP.pm
@@ -50,7 +50,7 @@ $VERSION = '3.37';
     'fdp_run'      => 'snFdpGlobalRun',
     'fdp_interval' => 'snFdpGlobalMessageInterval',
     'fdp_holdtime' => 'snFdpGlobalHoldTime',
-    'fdp_id'       => 'snFdpGlobalDeviceId',
+    'fdp_gid'      => 'snFdpGlobalDeviceId',
 );
 
 %FUNCS = (
@@ -231,7 +231,7 @@ Time in seconds that FDP messages are kept.
 
 (C<fdpGlobalHoldTime>)
 
-=item  $fdp->fdp_id() 
+=item  $fdp->fdp_gid()
 
 Returns FDP device ID.  
 


### PR DESCRIPTION
Without this, the FDP module doesn't return any device IDs. 