### PR TITLE
Enhanced Ubiquiti device support

### DIFF
--- a/lib/SNMP/Info.pm
+++ b/lib/SNMP/Info.pm
@@ -634,7 +634,7 @@ See documentation in L<SNMP::Info::Layer2::Trapeze> for details.
 
 =item SNMP::Info::Layer2::Ubiquiti
 
-SNMP Interface to Ubiquiti Access Points
+SNMP Interface to Ubiquiti Access Points and other devices
 
 See documentation in L<SNMP::Info::Layer2::Ubiquiti> for details.
 
@@ -1550,6 +1550,7 @@ sub device_type {
         30065 => 'SNMP::Info::Layer3::Arista',
         35098 => 'SNMP::Info::Layer3::Pica8',
         41112 => 'SNMP::Info::Layer2::Ubiquiti',
+        4413 => 'SNMP::Info::Layer2::Ubiquiti',
     );
 
     my %l2sysoidmap = (

--- a/lib/SNMP/Info/Layer2/Ubiquiti.pm
+++ b/lib/SNMP/Info/Layer2/Ubiquiti.pm
@@ -149,7 +149,10 @@ sub model {
         }
 
         ## If people have other models to further fine-tune this logic that would be great. 
-        if($ethCount eq 8){
+        if($ethCount eq 9){
+            ## Should be ER Infinity
+            return "EdgeRouter Infinity"
+        }if($ethCount eq 8){
             ## Could be ER-8 Pro, ER-8, or EP-R8
             return "EdgeRouter 8-Port"
         }elsif($ethCount eq 5 and $cpuCount eq 4){

--- a/lib/SNMP/Info/Layer2/Ubiquiti.pm
+++ b/lib/SNMP/Info/Layer2/Ubiquiti.pm
@@ -72,7 +72,8 @@ sub os_ver {
     foreach my $iid ( keys %$versions ) {
         my $ver = $versions->{$iid};
         next unless defined $ver;
-	    return $ver;
+        return $ver;
+        ## Not sure what this function does, it seems to be extraneous being in the same code block after a return statement?
         if ( $ver =~ /([\d\.]+)/ ) {
             return $1;
         }


### PR DESCRIPTION
added logic to include EdgeMax devices in the Ubiquiti pm file

Not sure if this file needs to be moved to Layer3 or not? 

I have ~350 UBNT devices that i tested this against with no noticeable issues, but I do not have one of every type of device. Notably:
- We *only* have NanoStation M5 AirOS devices
- We *don't* gather info on UniFi devices, but I did a discover of a couple and it seems to pull just as well as AirOS
- We *don't* have the following EdgeRouter models in production or in stock
  - ER-8 (non pro)
  - EdgePoint
  - ER-X-SFP
  - ER-Infinity (seems like that device has 9 eth ports, so this may work, it's just untested)