### PR TITLE
Improvement for Checkpoint, CiscoSB and H3C devices

### DIFF
--- a/lib/SNMP/Info.pm
+++ b/lib/SNMP/Info.pm
@@ -1522,6 +1522,7 @@ sub device_type {
         2011 => 'SNMP::Info::Layer3::Huawei',
         2021 => 'SNMP::Info::Layer3::NetSNMP',
         2272 => 'SNMP::Info::Layer3::Passport',
+        2620 => 'SNMP::Info::Layer3::Checkpoint',
         2636 => 'SNMP::Info::Layer3::Juniper',
         2925 => 'SNMP::Info::Layer1::Cyclades',
         3076 => 'SNMP::Info::Layer3::Altiga',

--- a/lib/SNMP/Info.pm
+++ b/lib/SNMP/Info.pm
@@ -1691,6 +1691,11 @@ sub device_type {
         $objtype = 'SNMP::Info::Layer3::CiscoFWSM'
             if ( $desc =~ /Cisco Firewall Services Module/i );
         
+        #   Cisco Small Business (300 500) series override
+        #   This is for enterprises(1).cisco(9).otherEnterprises(6).ciscosb(1)
+        $objtype = 'SNMP::Info::Layer2::CiscoSB'
+            if ( $soid =~ /^\.?1\.3\.6\.1\.4\.1\.9\.6\.1/ );
+
         # Avaya Secure Router
         $objtype = 'SNMP::Info::Layer3::Tasman'
             if ( $desc =~ /^(avaya|nortel)\s+(SR|secure\srouter)\s+\d{4}/i );

--- a/lib/SNMP/Info/Layer2/3Com.pm
+++ b/lib/SNMP/Info/Layer2/3Com.pm
@@ -73,6 +73,8 @@ sub model {
     my $descr = $dsmodel->description();
     if ( $descr =~ /^([\S ]+) Software.*/){
         return $1;
+    } else {
+        return $descr;
     }
 }
 

--- a/lib/SNMP/Info/Layer2/CiscoSB.pm
+++ b/lib/SNMP/Info/Layer2/CiscoSB.pm
@@ -130,8 +130,9 @@ sub model {
 
     foreach my $e ( sort keys %$e_model ) {
         if (defined $e_model->{$e} and $e_model->{$e} !~ /^\s*$/) {
-            my $model = "$e_model->{$e} $e_hwver->{$e}";
-            return $model;
+            return $e_model->{$e};
+            #my $model = "$e_model->{$e} $e_hwver->{$e}";
+            #return $model;
         }
     }
     return $ciscosb->description();

--- a/lib/SNMP/Info/Layer3/Checkpoint.pm
+++ b/lib/SNMP/Info/Layer3/Checkpoint.pm
@@ -1,0 +1,330 @@
+# SNMP::Info::Layer3::Checkpoint
+# $Id$
+#
+# Copyright (c) 2008 Bill Fenner
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the University of California, Santa Cruz nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR # ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+package SNMP::Info::Layer3::Checkpoint;
+
+use strict;
+use Exporter;
+use SNMP::Info::Layer3;
+use SNMP::Info::LLDP;
+
+@SNMP::Info::Layer3::Checkpoint::ISA       = qw/SNMP::Info::LLDP SNMP::Info::Layer3 Exporter/;
+@SNMP::Info::Layer3::Checkpoint::EXPORT_OK = qw//;
+
+use vars qw/$VERSION %GLOBALS %MIBS %FUNCS %MUNGE/;
+
+$VERSION = '3.37';
+
+%MIBS = (
+    %SNMP::Info::Layer3::MIBS,
+    %SNMP::Info::LLDP::MIBS,
+    'CHECKPOINT-MIB'      => 'fwProduct',
+    'UCD-SNMP-MIB'        => 'versionTag',
+    'NET-SNMP-TC'         => 'netSnmpAgentOIDs',
+    'NET-SNMP-EXTEND-MIB' => 'nsExtendNumEntries',
+    'HOST-RESOURCES-MIB'  => 'hrSystem',
+);
+
+%GLOBALS = (
+    %SNMP::Info::Layer3::GLOBALS,
+    %SNMP::Info::LLDP::GLOBALS,
+    'netsnmp_vers'   => 'versionTag',
+    'hrSystemUptime' => 'hrSystemUptime',
+    
+);
+
+%FUNCS = (
+    %SNMP::Info::Layer3::FUNCS,
+    %SNMP::Info::LLDP::FUNCS,
+
+    # Net-SNMP Extend table that could but customize to add a the Checkpoint version
+    'extend_output_table' => 'nsExtendOutputFull',
+);
+
+%MUNGE = (
+    %SNMP::Info::Layer3::MUNGE,
+    %SNMP::Info::LLDP::MUNGE,
+);
+
+sub vendor {
+    return 'checkpoint';
+}
+
+sub model {
+    my $ckp = shift;
+    my $id = $ckp->id;
+
+    my $model = &SNMP::translateObj($id);
+
+    if (defined $model) {
+        $model =~ s/^checkPoint//;
+        return $model;
+    } else {
+        return $id;
+    }
+}
+
+sub os {
+    return 'checkpoint';
+}
+
+sub os_ver {
+    my $ckp = shift;
+    my $extend_table = $ckp->extend_output_table() || {};
+
+    my $descr   = $ckp->description();
+    my $vers    = $ckp->netsnmp_vers();
+    my $os_ver  = undef;
+
+    foreach my $ex (keys %$extend_table) {
+        (my $name = pack('C*',split(/\./,$ex))) =~ s/[^[:print:]]//g;
+        if ($name eq 'ckpVersion') {
+            return $1 if ($extend_table->{$ex} =~ /^This is Check Point's software version (.*)$/);
+            last;
+        }
+    } 
+
+    $os_ver = $1 if ( $descr =~ /^\S+\s+\S+\s+(\S+)\s+/ );
+    if ($vers) {
+        $os_ver = "???" unless defined($os_ver);
+        $os_ver .= " / Net-SNMP " . $vers;
+    }
+
+    return $os_ver;
+}
+
+sub serial {
+    my $ckp = shift;
+    my $extend_table = $ckp->extend_output_table() || {};
+
+    foreach my $ex (keys %$extend_table) {
+        (my $name = pack('C*',split(/\./,$ex))) =~ s/[^[:print:]]//g;
+        if ($name eq 'ckpAsset') {
+            return $1 if ($extend_table->{$ex} =~ /Serial Number: (\S+)/);
+            last;
+        }
+    }
+
+    return '';
+}
+
+sub layers {
+    return '01001100';
+}
+
+# sysUptime gives us the time since the SNMP daemon has restarted,
+# so return the system uptime since that's probably what the user
+# wants.  (Caution: this could cause trouble if using
+# sysUptime-based discontinuity timers or other TimeStamp
+# objects.
+sub uptime {
+    my $ckp = shift;
+    my $uptime;
+
+    $uptime = $ckp->hrSystemUptime();
+    return $uptime if defined $uptime;
+
+    return $ckp->SUPER::uptime();
+}
+
+sub i_ignore {
+    my $l3      = shift;
+    my $partial = shift;
+
+    my $interfaces = $l3->interfaces($partial) || {};
+
+    my %i_ignore;
+    foreach my $if ( keys %$interfaces ) {
+
+        # lo0 etc
+        if ( $interfaces->{$if} =~ /\blo\d*\b/i ) {
+            $i_ignore{$if}++;
+        }
+    }
+    return \%i_ignore;
+}
+
+1;
+__END__
+
+=head1 NAME
+
+SNMP::Info::Layer3::Checkpoint - SNMP Interface to Checkpoint Devices
+
+=head1 AUTHORS
+
+Ambroise Rosset
+
+=head1 SYNOPSIS
+
+ # Let SNMP::Info determine the correct subclass for you. 
+ my $ckp = new SNMP::Info(
+                          AutoSpecify => 1,
+                          Debug       => 1,
+                          DestHost    => 'myrouter',
+                          Community   => 'public',
+                          Version     => 2
+                        ) 
+    or die "Can't connect to DestHost.\n";
+
+ my $class      = $ckp->class();
+ print "SNMP::Info determined this device to fall under subclass : $class\n";
+
+=head1 DESCRIPTION
+
+Subclass for Generic Net-SNMP devices
+
+=head2 WARNING
+
+To correctly and completelly work, you should add the following line in the file C</etc/snmp/snmpd.local.conf> on each of your Checkpoint devices:
+
+ # Netdisco SNMP configuration
+ extend  ckpVersion /opt/CPsuite-R77/fw1/bin/fw ver
+ extend  ckpAsset /bin/clish -c 'show asset all'
+
+=head2 Inherited Classes
+
+=over
+
+=item SNMP::Info::Layer3
+
+=back
+
+=head2 Required MIBs
+
+=over
+
+=item F<UCD-SNMP-MIB>
+
+=item F<NET-SNMP-TC>
+
+=item F<HOST-RESOURCES-MIB>
+
+=item Inherited Classes' MIBs
+
+See L<SNMP::Info::Layer3> for its own MIB requirements.
+
+See L<SNMP::Info::LLDP> for its own MIB requirements.
+
+=back
+
+=head1 GLOBALS
+
+These are methods that return scalar value from SNMP
+
+=over
+
+=item $ckp->vendor()
+
+Returns 'checkpoint'.
+
+=item $ckp>model()
+
+Return the model type of the Checkpoint device (Based on the sysObjectOID translation).
+
+=item $ckp->os()
+
+Returns the OS extracted from C<sysDescr>.
+
+=item $ckp->os_ver()
+
+Returns the software version extracted from C<sysDescr>, along
+with the Net-SNMP version.
+
+=item $ckp->uptime()
+
+Returns the system uptime instead of the agent uptime.
+NOTE: discontinuity timers and other Time Stamp based objects
+are based on agent uptime, so use orig_uptime().
+
+=item $ckp->serial()
+
+Return the serial number of the device if the SNMP server is configured as indicated previously.
+Return '' in other case.
+
+=item $ckp->layers()
+
+Return '01001100'.
+
+=back
+
+=head2 Globals imported from SNMP::Info::Layer3
+
+See documentation in L<SNMP::Info::Layer3> for details.
+
+=head2 Globals imported from SNMP::Info::LLDP
+
+See documentation in L<SNMP::Info::LLDP> for details.
+
+=head1 TABLE ENTRIES
+
+These are methods that return tables of information in the form of a reference
+to a hash.
+
+=head2 Overrides
+
+=over
+
+=item $ckp->i_ignore()
+
+Returns reference to hash.  Increments value of IID if port is to be ignored.
+
+Ignores loopback
+
+=back
+
+=head2 Table Methods imported from SNMP::Info::Layer3
+
+See documentation in L<SNMP::Info::Layer3> for details.
+
+=head2 Table Methods imported from SNMP::Info::LLDP
+
+See documentation in L<SNMP::Info::LLDP> for details.
+
+=head1 NOTES
+
+In order to cause SNMP::Info to classify your device into this class, it
+may be necessary to put a configuration line into your F<snmpd.conf>
+similar to
+
+  sysobjectid .1.3.6.1.4.1.8072.3.2.N
+
+where N is the object ID for your OS from the C<NET-SNMP-TC> MIB (or
+255 if not listed).  Some Net-SNMP installations default to an
+incorrect return value for C<system.sysObjectId>.
+
+In order to recognize a Net-SNMP device as Layer3, it may be necessary
+to put a configuration line similar to
+
+  sysservices 76
+
+in your F<snmpd.conf>.
+
+=cut

--- a/lib/SNMP/Info/Layer3/H3C.pm
+++ b/lib/SNMP/Info/Layer3/H3C.pm
@@ -85,6 +85,20 @@ sub vendor {
     return $mfg->{1} || "H3C";
 }
 
+sub model {
+    my $h3c = shift;
+    
+    my $descr = $h3c->description();
+    if ($descr =~ /^.*\n(.*)\n/) {
+        return $1;
+    } elsif ($h3c->entPhysicalClass(2)->{2} =~ /^(3|chassis)$/) {
+        return $h3c->entPhysicalName(2)->{2};
+    } else {
+        my $id = $h3c->id();
+        return &SNMP::translateObj($id) || $id;
+    }
+}
+
 sub os {
     my $h3c = shift;
     my $descr   = $h3c->description();


### PR DESCRIPTION
Add the following functionnality:
- add hability to have a better intergration on Checkpoint firewall
  (need a modification on the Checkpoint device that is explain on the documentation of the Checkpoint.pm)
- add a better model display for H3C/3Com devices
- Some CiscoSB could work at layer 3 and we could have an issue for the model when we have at the same time the model + HW ver (many different inventory devices)