### PR TITLE
Improve F10 OS version detection

### DIFF
--- a/lib/SNMP/Info/Layer3/Force10.pm
+++ b/lib/SNMP/Info/Layer3/Force10.pm
@@ -89,7 +89,7 @@ sub os_ver {
     my $descr   = $force10->description();
     my $os_ver  = undef;
 
-    $os_ver = $1 if ( $descr =~ /Force10\s+Application\s+Software\s+Version:\s+(\S+)/s );
+    $os_ver = $1 if ( $descr =~ /\s+Application\s+Software\s+Version:\s+(\S+)/s );
 
     return $os_ver;
 }


### PR DESCRIPTION
Previous regex was not matching in some cases

ex: "Dell Networking OS Operating System Version: 2.0 Application Software Version: 9.11(0.0P6) Series: S3048-ON Copyright (c) 1999-2017 by Dell Inc. All Rights Reserved. Build Time: Mon Feb 27 16:56:22 2017" did not match previous regex