### PR TITLE
detect ap250 & ap230 models

### DIFF
--- a/lib/SNMP/Info/Layer2/Aerohive.pm
+++ b/lib/SNMP/Info/Layer2/Aerohive.pm
@@ -106,7 +106,7 @@ sub model {
     my $aerohive = shift;
     my $descr    = $aerohive->description();
 
-    if ( $descr =~ m/\bHive(AP\d+)\b/ix ) {
+    if ( $descr =~ m/\b((Hive|)AP\d+)\b/ix ) {
         return $1;
     }
     return;


### PR DESCRIPTION
it seems aerohive changed the their model names in snmp, so they no langer always begin with "hive". i have access to models 120, 121, 230 & 250. this is their sysdescr:

SNMPv2-MIB::sysDescr.0 = STRING: AP250, HiveOS 8.3r2 build-191018
SNMPv2-MIB::sysDescr.0 = STRING: AP230, HiveOS 6.5r8b build-179369
SNMPv2-MIB::sysDescr.0 = STRING: HiveAP121, HiveOS 6.5r8b build-179369
SNMPv2-MIB::sysDescr.0 = STRING: HiveAP120, HiveOS 6.5r3 Honolulu build2530

this fixes empty model names for the 230 & 250 ones while still supporting 120 & 121

Class SNMP::Info::Layer2::Aerohive (3.59) loaded from SNMP::Info 3.59.
Connected to hiveap211.
Detected Class: SNMP::Info::Layer2::Aerohive
Using    Class: SNMP::Info::Layer2::Aerohive (-c to change)

Fetching base info...

vendor               aerohive
model                AP250
os                   hiveos
os_ver               8.3r2
description          AP250, HiveOS 8.3r2 build-191018
contact              admin@aerohive.com



Class SNMP::Info::Layer2::Aerohive (3.59) loaded from SNMP::Info 3.59.
Connected to hiveap113.
Detected Class: SNMP::Info::Layer2::Aerohive
Using    Class: SNMP::Info::Layer2::Aerohive (-c to change)

Fetching base info...

vendor               aerohive
model                HiveAP121
os                   hiveos
os_ver               6.5r8b
description          HiveAP121, HiveOS 6.5r8b build-179369
contact              admin@aerohive.com