### PR TITLE
Add support for additional Mikrotik models

### DIFF
--- a/lib/SNMP/Info/Layer3/Mikrotik.pm
+++ b/lib/SNMP/Info/Layer3/Mikrotik.pm
@@ -79,6 +79,7 @@ sub model {
     my $descr = $mikrotik->description() || '';
     my $model = undef;
     $model = $1 if ( $descr =~ /^RouterOS\s+(\S+)$/i );
+    $model = $1 if ( $descr =~ /^RouterOS\s+(RB .*)$/i );
     return $model;
 }
 


### PR DESCRIPTION
Add additional regex to catch additional valid Mikrotik hardware models; these include:

    RB Groove A-2Hn
    RB Groove A-5Hn
    RB Metal 2SHPn
    RB Metal 5SHPn
    RB Metal 9HPn
    RB SXT 5HPnD
    RB SXT 5HPnD r2
    RB SXT 5nD r2
    RB SXT G-5HPacD
    RB SXT G-5HPnD r2
   
Among others.