### PR TITLE
return aerohive serial

### DIFF
--- a/lib/SNMP/Info/Layer2/Aerohive.pm
+++ b/lib/SNMP/Info/Layer2/Aerohive.pm
@@ -92,6 +92,12 @@ sub os {
     return 'hiveos';
 }
 
+sub serial {
+    my $aerohive = shift;
+
+    return $aerohive->ahSystemSerial();
+}
+
 sub os_ver {
     my $aerohive = shift;
     my $descr    = $aerohive->description();


### PR DESCRIPTION
no idea why this is needed, but without this change no serial is returned:

netdisco-do show -d hiveap207 -e serial
[25474] 2018-11-09 19:45:09  info App::Netdisco version 2.039031 loaded.
[25474] 2018-11-09 19:45:10  info show: [10.40.252.14]/serial started at Fri Nov  9 20:45:10 2018
undef
[25474] 2018-11-09 19:45:10  info show: finished at Fri Nov  9 20:45:10 2018
[25474] 2018-11-09 19:45:10  info show: status done: Showed serial response from 10.40.252.14

netdisco-do show -d hiveap207 -e Layer2::Aerohive::serial
[25491] 2018-11-09 19:45:15  info App::Netdisco version 2.039031 loaded.
[25491] 2018-11-09 19:45:15  info show: [10.40.252.14]/Layer2::Aerohive::serial started at Fri Nov  9 20:45:15 2018
undef
[25491] 2018-11-09 19:45:16  info show: finished at Fri Nov  9 20:45:16 2018
[25491] 2018-11-09 19:45:16  info show: status done: Showed serial response from 10.40.252.14



with the change:
netdisco-do show -d hiveap207 -e Layer2::Aerohive::serial
[23072] 2018-11-09 19:44:06  info App::Netdisco version 2.039031 loaded.
[23072] 2018-11-09 19:44:07  info show: [10.40.252.14]/Layer2::Aerohive::serial started at Fri Nov  9 20:44:07 2018
02501610110274
[23072] 2018-11-09 19:44:07  info show: finished at Fri Nov  9 20:44:07 2018
[23072] 2018-11-09 19:44:07  info show: status done: Showed serial response from 10.40.252.14

netdisco-do show -d hiveap207 -e serial
[23075] 2018-11-09 19:44:13  info App::Netdisco version 2.039031 loaded.
[23075] 2018-11-09 19:44:13  info show: [10.40.252.14]/serial started at Fri Nov  9 20:44:13 2018
02501610110274
[23075] 2018-11-09 19:44:14  info show: finished at Fri Nov  9 20:44:14 2018
[23075] 2018-11-09 19:44:14  info show: status done: Showed serial response from 10.40.252.14