### PR TITLE
fix cisco agg_ports #295

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,7 +2,14 @@ Version 3.65 ()
 
   [ENHANCEMENTS]
 
-  * Add two more HP 2930F models
+  * Add two more HP 2930F models (JeroenvIS)
+  * #296 expand CiscoAgg to also include LACP based aggregated links
+    and staticly aggregated links. (inphobia)
+
+  [BUG FIXES]
+
+  * #295 make CiscoAgg return ifindex like expected instead of
+    bp_index (inphobia)
 
 Version 3.64 (2018-12-30)
 

--- a/lib/SNMP/Info/CiscoAgg.pm
+++ b/lib/SNMP/Info/CiscoAgg.pm
@@ -1,6 +1,6 @@
 # SNMP::Info::CiscoAgg
 #
-# Copyright (c) 2018 SNMP::Info Developers
+# Copyright (c) 2019 SNMP::Info Developers
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -171,7 +171,7 @@ SNMP::Info Developers
 =head1 DESCRIPTION
 
 This class provides access to Aggregated Links configuration on Cisco devices.
-It combines Cisco PAgP and IEEE 802.3ad information.
+It combines Cisco PAgP, Cisco proprietary info and IEEE 802.3ad information.
 
 Use or create in a subclass of SNMP::Info.  Do not use directly.
 
@@ -206,16 +206,18 @@ ifIndex of the corresponding master ports.
 =item C<agg_ports_cisco>
 
 Implements the cisco LAG info retrieval. Merged into C<agg_ports> data
-automatically.
+automatically. Will fetch all members of C<clagAggPortListInterfaceIndexList>
+even if they are not running an aggregation protocol.
 
 =item C<agg_ports_pagp>
 
 Implements the PAgP LAG info retrieval. Merged into C<agg_ports> data
 automatically.
 
-=item C<munge_port_ifindex>
+=item C<lag_members>
 
-needs documentation. maps lag masters to slave ifindex.
+Mimics C<ad_lag_ports> from L<SNMP::Info::IEEE802dot3ad> but based on ifindex
+instead of instead of bp_index.
 
 =back
 
@@ -232,6 +234,21 @@ It will be merged into C<agg_ports> data.
 
 =head2 Table Methods imported from SNMP::Info::IEEE802dot3ad
 
+=over
+
 See documentation in L<SNMP::Info::IEEE802dot3ad> for details.
+
+=back
+
+=head1 MUNGES
+
+=over
+
+=item C<munge_port_ifindex>
+
+Takes C<clagAggPortListInterfaceIndexList>, uses the index as master port, then
+returns all members as ifindex. Works with single or multiple slaves to a master.
+
+=back
 
 =cut

--- a/lib/SNMP/Info/CiscoAgg.pm
+++ b/lib/SNMP/Info/CiscoAgg.pm
@@ -80,6 +80,25 @@ sub agg_ports_pagp {
   return $mapping;
 }
 
+sub agg_ports_lag {
+  my $dev = shift;
+
+  # same note as for agg_ports_pagp, it will miss mappings if interfaces
+  # are down or lacp is not synced.
+
+  my $mapping = {};
+  my $group = $dev->dot3adAggPortSelectedAggID;
+  for my $slave (keys %$group) {
+    my $master = $group->{$slave};
+    next if($master == 0 || $slave == $master);
+
+    $mapping->{$slave} = $master;
+  }
+
+  return $mapping;
+}
+
+
 # until we have PAgP data and need to combine with LAG data
 sub agg_ports {
   my $ret = {%{agg_ports_pagp(@_)}, %{agg_ports_lag(@_)}};
@@ -148,6 +167,13 @@ ifIndex of the corresponding master ports.
 
 Implements the PAgP LAG info retrieval. Merged into C<agg_ports> data
 automatically.
+
+=head2 OVERRIDES
+
+=item C<agg_ports_lag>
+
+This will retrieve LAG ports based on C<dot3adAggPortSelectedAggID> data.
+It will be merged into C<agg_ports> data.
 
 =back
 

--- a/lib/SNMP/Info/CiscoAgg.pm
+++ b/lib/SNMP/Info/CiscoAgg.pm
@@ -213,6 +213,10 @@ automatically.
 Implements the PAgP LAG info retrieval. Merged into C<agg_ports> data
 automatically.
 
+=item C<munge_port_ifindex>
+
+needs documentation. maps lag masters to slave ifindex.
+
 =back
 
 =head2 OVERRIDES

--- a/lib/SNMP/Info/CiscoAgg.pm
+++ b/lib/SNMP/Info/CiscoAgg.pm
@@ -168,7 +168,11 @@ ifIndex of the corresponding master ports.
 Implements the PAgP LAG info retrieval. Merged into C<agg_ports> data
 automatically.
 
+=back
+
 =head2 OVERRIDES
+
+=over
 
 =item C<agg_ports_lag>
 


### PR DESCRIPTION
netdisco/snmp-info#295 for details

if agg_ports says it returns ifindex keys, it should never use bp_index mappings unless they can be mapped on ifindex.

since ciscoagg is used by a lot of classes testing on more devices would be nice.

ports need to be up & have lacp in sync to be discovered.