### PR TITLE
massive amount of trailing whitespace cleanup

### DIFF
--- a/Changes
+++ b/Changes
@@ -37,7 +37,7 @@ Version 3.62 (2018-10-29)
   * #275 Document peth_port_ifindex for Junipers
   * #274 Add peth_port_ifindex override for Junipers
   * #270 Add support for additional Mikrotik models
-  * Add HP 3810M, 2930M, 2930F and 2540 series switches 
+  * Add HP 3810M, 2930M, 2930F and 2540 series switches
 
   [BUG FIXES]
 
@@ -127,7 +127,7 @@ Version 3.56 (2018-04-22)
   [BUG FIXES]
 
   * Fix table methods when defined as an OID which will not completely
-    translate to a fully qualified textual leaf 
+    translate to a fully qualified textual leaf
 
 Version 3.55 (2018-04-19)
 
@@ -160,7 +160,7 @@ Version 3.55 (2018-04-19)
     ports() of L3::C3550
   * Correct validation and IID/key used in mau_set_i_speed_admin() and
     mau_set_i_duplex_admin() of MAU
-  * Correct typo in MIB leaf names in L3::Aironet 
+  * Correct typo in MIB leaf names in L3::Aironet
   * Don't use MIB leafs that are not-accessible according to MIB
     NOTE: Fixing this logic now results in methods on MIB leafs specified as
     not-accessible failing validation in _validate_autoload_method()
@@ -223,7 +223,7 @@ version 3.50 (2018-03-14)
 
   * #226 Avaya VSP devices - no ifAlias
   * #227 Remove bogus can() check in _set()
-  * Fix SNMP::Info::IEEE802dot3ad when more than 1 LAG 
+  * Fix SNMP::Info::IEEE802dot3ad when more than 1 LAG
 
 version 3.49 (2018-03-03)
 

--- a/LICENSE
+++ b/LICENSE
@@ -6,7 +6,7 @@ Original Code
 Copyright (c) 2002,2003 Regents of the University of California
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without 
+Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
     * Redistributions of source code must retain the above copyright notice,
@@ -14,17 +14,17 @@ modification, are permitted provided that the following conditions are met:
     * Redistributions in binary form must reproduce the above copyright notice,
       this list of conditions and the following disclaimer in the documentation
       and/or other materials provided with the distribution.
-    * Neither the name of the University of California, Santa Cruz nor the 
-      names of its contributors may be used to endorse or promote products 
+    * Neither the name of the University of California, Santa Cruz nor the
+      names of its contributors may be used to endorse or promote products
       derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
 ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
 LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -58,7 +58,7 @@
 # Avoid Devel::Cover and Devel::CoverX::Covered files.
 \bcover_db\b
 \bcovered\b
- 
+
 # Avoid MYMETA files
 ^MYMETA\.
 

--- a/contrib/DEVELOP
+++ b/contrib/DEVELOP
@@ -6,7 +6,7 @@ Coding Guidelines:
     - always update ChangeLog before committing
     - check-in required mibs to netdisco-mibs and release new package if needed
 
-Release and Testing Instructions: 
+Release and Testing Instructions:
     - for netdisco see:
         -> https://github.com/netdisco/netdisco/wiki/Developing
         -> https://metacpan.org/pod/App::Netdisco
@@ -17,17 +17,17 @@ Release and Testing Instructions:
         -> https://github.com/netdisco/netdisco-mibs/wiki
 
 FAQ:
-    - Do I have to update the version number and timestamp in modified files before committing? 
+    - Do I have to update the version number and timestamp in modified files before committing?
     -> No.  These are RCS tags that are automatically updated by CVS when you commit
 
     - Should I add changes at the top of the ChangeLog?
     -> Yes. The changelog is created one commit at a time.  If there isn't a
         section for the current version, then add one at the top and put your
-        changes after.  You can leave the date field for the release empty (). 
+        changes after.  You can leave the date field for the release empty ().
 
     - What should I change the $VERSION to?
     -> If you are the first person to get to a file after a release, update it
-       to either  release++ or "release++ dash cvs".   
+       to either  release++ or "release++ dash cvs".
        Example: File is marked 2.01, change it to 2.02-cvs with your new changes.
        Example: File is marked 2.02-cvs,  no change until packaging for release when the -cvs is removed.
        TODO: Is there still an odd/even scheme as introduced by Eric?

--- a/contrib/util/make_dev_matrix.pl
+++ b/contrib/util/make_dev_matrix.pl
@@ -28,7 +28,7 @@ if ($@) {
             } else {
                 $graph{$vendor}->{$family}=[];
             }
-            
+
         }
     }
     my $now = scalar localtime;
@@ -83,7 +83,7 @@ foreach my $vendor (sort sort_nocase keys %$matrix){
                 } elsif (defined $vendor_defaults->{$a}){
                     $val = $vendor_defaults->{$a};
                     $class = 'vendor';
-                } 
+                }
                 print "  <TD CLASS='$class'>",join("<BR>\n",@$val),"</TD>\n";
             }
             print "</TR></TABLE>\n";
@@ -141,7 +141,7 @@ sub parse_data {
 
         my ($cmd,$value);
         if ($line =~ /^([a-z-_]+)\s*:\s*(.*)$/) {
-            $cmd = $1;  $value = $2; 
+            $cmd = $1;  $value = $2;
         } else {
             print "What do i do with this line : $line \n";
             next;
@@ -164,18 +164,18 @@ sub parse_data {
             $family = $value;
             $model = undef;
             print "$family has no vendor.\n" unless defined $vendor;
-            $Matrix->{$vendor}->{families}->{$family} = {} 
+            $Matrix->{$vendor}->{families}->{$family} = {}
                 unless defined $Matrix->{$vendor}->{families}->{$family};
             $class = $Matrix->{$vendor}->{families}->{$family};
             $class->{defaults}->{type}='family';
             next;
-        }   
+        }
 
         if ($cmd eq 'device') {
             $model = $value;
             print "$model has no family.\n" unless defined $family;
             print "$model has no vendor.\n" unless defined $vendor;
-            $Matrix->{$vendor}->{families}->{$family}->{models}->{$model} = {} 
+            $Matrix->{$vendor}->{families}->{$family}->{models}->{$model} = {}
                 unless defined $Matrix->{$vendor}->{families}->{$family}->{models}->{$model};
             $class = $Matrix->{$vendor}->{families}->{$family}->{models}->{$model};
             $class->{defaults}->{type}='device';
@@ -233,7 +233,7 @@ sub html_head {
     .vendor { font-size:12pt; color:#777777; }
     .family { font-size:12pt; color:blue; }
     .model  { font-size:12pt; color:red; }
-    .note   { color:red; } 
+    .note   { color:red; }
 //-->
 </STYLE>
 </HEAD>
@@ -304,7 +304,7 @@ be assumed working.
         Discovery Protocol (LLDP), Cisco Discovery Protocol (CDP),
         SynOptics/Bay/Nortel/Avaya Network Management Protocol (SONMP),
         Foundry/Brocade Discovery Protocol (FDP), Extreme Discovery
-        Protocol (EDP), and Alcatel Mapping Adjacency Protocol (AMAP). 
+        Protocol (EDP), and Alcatel Mapping Adjacency Protocol (AMAP).
     </TD>
 </TR>
 <TR>
@@ -325,7 +325,7 @@ be assumed working.
 </BODY>
 </HTML>
 end_tail
-    
+
 }
 
 sub print_headers {

--- a/contrib/util/make_snmpdata.pl
+++ b/contrib/util/make_snmpdata.pl
@@ -80,7 +80,7 @@ unless ( defined $sysdescr ) {
 
 SNMP::loadModules(@ARGV);
 
-# Create a hash of MIB Modules for which we want results 
+# Create a hash of MIB Modules for which we want results
 my %mib_hash = map {$_ => 1} @ARGV;
 # Add the common MIB Modules we always want
 my @common_mibs = ('SNMPv2-MIB', 'IF-MIB');

--- a/contrib/util/push_ver
+++ b/contrib/util/push_ver
@@ -35,7 +35,7 @@ sub glob_rec {
 
     foreach my $f (@files) {
         next if $f eq '\.$';
-        
+
         if (-d $f) {
             push @pms, glob_rec($f);
             next;

--- a/contrib/util/test_class.pl
+++ b/contrib/util/test_class.pl
@@ -250,11 +250,11 @@ test_class.pl [options]
 
 Options:
 
-    -c|class    SNMP::Info class to use, Layer2::Catalyst    
+    -c|class    SNMP::Info class to use, Layer2::Catalyst
     -d|dev      Device
     -s|comm     SNMP community
     -v|ver      SNMP version
-    -p|print    Print values 
+    -p|print    Print values
     -i|ignore   Ignore Net-SNMP configuration file
     -m|mibdir   Directory containing MIB Files
     -n|nobulk   Disable bulkwalk
@@ -294,7 +294,7 @@ SNMP version. Default 2.
 =item B<-print>
 
 Print values of a class method rather than summarizing.  May be repeated
-multiple times. 
+multiple times.
 
 -print i_description -print i_type
 
@@ -308,7 +308,7 @@ provided.
 =item B<-mibdir>
 
 Directory containing MIB Files.  Multiple directories should be separated by a
-colon ':'. 
+colon ':'.
 
 -mibdir /usr/local/share/snmp/mibs/rfc:/usr/local/share/snmp/mibs/net-snmp
 

--- a/contrib/util/test_class_mocked.pl
+++ b/contrib/util/test_class_mocked.pl
@@ -385,9 +385,9 @@ test_class_mocked.pl [options]
 
 Options:
 
-    -class    SNMP::Info class to use, Layer2::Catalyst    
+    -class    SNMP::Info class to use, Layer2::Catalyst
     -file     File containing data gathered using make_snmpdata.pl
-    -print    Print values 
+    -print    Print values
     -debug    Debugging flag
     -ignore   Ignore Net-SNMP configuration file
     -mibdir   Directory containing MIB Files
@@ -414,7 +414,7 @@ mandatory option.
 =item B<-print>
 
 Print values of a class method rather than summarizing.  May be repeated
-multiple times. 
+multiple times.
 
 -print i_description -print i_type
 
@@ -434,7 +434,7 @@ provided.
 =item B<-mibdir>
 
 Directory containing MIB Files.  Multiple directories should be separated by a
-colon ':'. 
+colon ':'.
 
 -mibdir /usr/local/share/snmp/mibs/rfc:/usr/local/share/snmp/mibs/net-snmp
 

--- a/lib/SNMP/Info.pm
+++ b/lib/SNMP/Info.pm
@@ -1327,7 +1327,7 @@ sub new {
         $new_obj->{mibdirs} = $args{MibDirs};
         delete $sess_args{MibDirs};
     }
-    
+
     # For IPv6 hosts set transport
     if ( defined $sess_args{DestHost} ) {
         $sess_args{DestHost} = resolve_desthost($sess_args{DestHost});
@@ -2590,13 +2590,13 @@ See documentation in L<SNMP::Info::IPv6> for IPv6 Address Table.
 
 Maps the IPv4 addresses to the interface index
 
-(C<ipAdEntIfIndex>) or filtered and index modified (C<ipAddressIfIndex>) 
+(C<ipAdEntIfIndex>) or filtered and index modified (C<ipAddressIfIndex>)
 
 =item $info->ip_table()
 
 Maps the Table to the IPv4 address
 
-(C<ipAdEntAddr>) or address extracted from (C<ipAddressIfIndex>) 
+(C<ipAdEntAddr>) or address extracted from (C<ipAddressIfIndex>)
 
 =item $info->ip_netmask()
 
@@ -3874,12 +3874,12 @@ sub resolve_desthost {
     $desthost =~ s/^(?:udp6:|udpv6:|udpipv6:)//x;
 
     my $ip = NetAddr::IP::Lite->new($desthost);
-    
+
     if ($ip and $ip->bits == 32) {
         return $ip->addr;
     }
     elsif ($ip and $ip->bits == 128) {
-        return 'udp6:' . $ip->addr;        
+        return 'udp6:' . $ip->addr;
     }
     else {
        croak "Unable to resolve DestHost: $desthost to an IP\n";
@@ -4456,7 +4456,7 @@ sub _load_attr {
         # requests
 
         my ($leaf) = $qual_leaf =~ /::(.+)$/;
-        
+
         # If we weren't able to translate, we'll only have an OID
         $leaf = $oid unless defined $leaf;
 
@@ -4655,7 +4655,7 @@ sub snmp_connect_ip {
     my $comm = $self->snmp_comm();
 
     return if $self->{Offline};
-    
+
     $ip = resolve_desthost($ip);
     return if ( $ip eq '0.0.0.0' ) or ( $ip =~ /^127\./ );
 
@@ -4831,7 +4831,7 @@ sub _validate_autoload_method {
 
     # Validate that we have proper access for the operation
     my $access = '';
-    
+
     # Prevent autovivification by checking that MIB leaf exists
     if (exists $SNMP::MIB{$oid}) {
         $access = $SNMP::MIB{$oid}{'access'} || '';
@@ -4851,23 +4851,23 @@ sub _validate_autoload_method {
     }
 
      my $table_leaf = 0;
- 
+
     # This is an expensive check so we assume anything in the funcs and globals
     # hashes are known. Only for actual MIB leafs should we have to check the
-    # MIB. If the parent of the leaf has indexes it is contained within a table.   
+    # MIB. If the parent of the leaf has indexes it is contained within a table.
     if ($funcs->{$attr}) {
       $table_leaf = 1;
      }
     elsif (!$globals->{$attr}) {
 
-        # Prevent autovivification 
+        # Prevent autovivification
         if (exists $SNMP::MIB{$oid} &&
             exists $SNMP::MIB{$oid}{'parent'} &&
             exists $SNMP::MIB{$oid}{'parent'}{'indexes'} &&
             defined $SNMP::MIB{$oid}{'parent'}{'indexes'} &&
             scalar( @{$SNMP::MIB{$oid}{'parent'}{'indexes'}} ) > 0)
         {
-            $table_leaf = 1;    
+            $table_leaf = 1;
         }
      }
 

--- a/lib/SNMP/Info/AMAP.pm
+++ b/lib/SNMP/Info/AMAP.pm
@@ -240,10 +240,10 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- my $amap = new SNMP::Info ( 
+ my $amap = new SNMP::Info (
                              AutoSpecify => 1,
                              Debug       => 1,
-                             DestHost    => 'router', 
+                             DestHost    => 'router',
                              Community   => 'public',
                              Version     => 2
                            );
@@ -269,7 +269,7 @@ Eric Miller
 
 =head1 DESCRIPTION
 
-SNMP::Info::AMAP is a subclass of SNMP::Info that provides an object oriented 
+SNMP::Info::AMAP is a subclass of SNMP::Info that provides an object oriented
 interface to Alcatel Mapping Adjacency Protocol (AMAP) information through
 SNMP.
 
@@ -299,7 +299,7 @@ These are methods that return scalar values from SNMP
 
 =item $amap->hasAMAP()
 
-Is AMAP is active in this device?  
+Is AMAP is active in this device?
 
 =back
 
@@ -322,7 +322,7 @@ Returns the mapping to the SNMP Interface Table.
 
 Returns remote IPv4 addresses.  Note: AMAP returns all IP addresses associated
 with the remote device.  It would be preferable to include only one address
-since they should all originate from the same device, but amap_ip() can not 
+since they should all originate from the same device, but amap_ip() can not
 determine if all addresses are reachable from the network management
 application therefore all addresses are returned and the calling application
 must determine which address to use and if they are in fact from the same

--- a/lib/SNMP/Info/AdslLine.pm
+++ b/lib/SNMP/Info/AdslLine.pm
@@ -50,7 +50,7 @@ $VERSION = '3.64';
     'adsl_atuc_curr_tx_rate'        => 'adslAtucChanCurrTxRate',
     'adsl_atuc_prev_tx_rate'        => 'adslAtucChanPrevTxRate',
     'adsl_atuc_crc_block_len'       => 'adslAtucChanCrcBlockLength',
-    
+
     # ADSL-LINE-MIB::adslAturChanTable
     'adsl_atur_interleave_delay'    => 'adslAturChanInterleaveDelay',
     'adsl_atur_curr_tx_rate'        => 'adslAturChanCurrTxRate',
@@ -73,14 +73,14 @@ Alexander Hartmaier
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $info = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $info->class();
@@ -88,7 +88,7 @@ Alexander Hartmaier
 
 =head1 DESCRIPTION
 
-SNMP::Info::AdslLine is a subclass of SNMP::Info that provides 
+SNMP::Info::AdslLine is a subclass of SNMP::Info that provides
 information about the adsl interfaces of a device.
 
 Use or create in a subclass of SNMP::Info.  Do not use directly.

--- a/lib/SNMP/Info/Aggregate.pm
+++ b/lib/SNMP/Info/Aggregate.pm
@@ -84,14 +84,14 @@ SNMP::Info Developers
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $info = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $info->class();

--- a/lib/SNMP/Info/Airespace.pm
+++ b/lib/SNMP/Info/Airespace.pm
@@ -84,7 +84,7 @@ $VERSION = '3.64';
     'airespace_ess_ifname'    => 'bsnDot11EssInterfaceName',
     'airespace_ess_aclname'   => 'bsnDot11EssAclName',
     'airespace_ess_bcast'     => 'bsnDot11EssBroadcastSsid',
-    
+
     # AIRESPACE-WIRELESS-MIB::bsnAPTable
     'airespace_ap_mac'      => 'bsnAPDot3MacAddress',
     'airespace_ap_name'     => 'bsnAPName',
@@ -764,14 +764,14 @@ sub dot11_cur_tx_pwr_mw {
     my $partial   = shift;
     my $cur       = $airespace->airespace_apif_power($partial);
     my $pwr_abs   = $airespace->airespace_apif_a_pwr($partial);
-    
+
     my $dot11_cur_tx_pwr_mw = {};
     foreach my $idx ( keys %$cur ) {
         my $pwr = $cur->{$idx};
         if ( $pwr >= 1 && $pwr <= 8 ) {
 
-            my @pwr_list = split(/,/, $pwr_abs->{$idx} ); 
-            $dot11_cur_tx_pwr_mw->{$idx} = $pwr_list[$pwr-1]; 
+            my @pwr_list = split(/,/, $pwr_abs->{$idx} );
+            $dot11_cur_tx_pwr_mw->{$idx} = $pwr_list[$pwr-1];
 
         }
         else {
@@ -1087,7 +1087,7 @@ Eric Miller
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
 
     or die "Can't connect to DestHost.\n";
 
@@ -1204,7 +1204,7 @@ valid only when the Transfer Mode is tftp.
 =item $airespace->airespace_ul_path()
 
 Transfer upload tftp path configures the directory path where the file is to
-be uploaded to. The switch remembers the last file path used. 
+be uploaded to. The switch remembers the last file path used.
 
 (C<agentTransferUploadPath>)
 
@@ -1279,7 +1279,7 @@ radio interface.
 =item $airespace->i_ssidmac()
 
 With the same keys as i_ssidlist, returns the Basic service set
-identification (BSSID), MAC address, the AP is using for the SSID. 
+identification (BSSID), MAC address, the AP is using for the SSID.
 
 =back
 
@@ -1346,7 +1346,7 @@ Name of the interface used by this WLAN.
 Name of ACL for the WLAN. This is applicable only when Web Authentication is
 enabled.
 
-(C<bsnDot11EssAclName>)           
+(C<bsnDot11EssAclName>)
 
 =item $airespace->airespace_ess_bcast()
 
@@ -1672,14 +1672,14 @@ to an empty string.
 
 =item $airespace->i_index()
 
-Returns reference to map of IIDs to Interface index. 
+Returns reference to map of IIDs to Interface index.
 
 Extends C<ifIndex> to support thin APs and WLAN virtual interfaces as device
 interfaces.
 
 =item $airespace->interfaces()
 
-Returns reference to map of IIDs to ports.  Thin APs are implemented as device 
+Returns reference to map of IIDs to ports.  Thin APs are implemented as device
 interfaces.  The thin AP MAC address airespace_ap_mac() and Slot ID
 airespace_apif_slot() are used as the port identifier.  Virtual interfaces
 use airespace_if_name() as the port identifier.
@@ -1717,7 +1717,7 @@ for thin AP interfaces.
 =item $airespace->i_mac()
 
 Returns reference to map of IIDs to MAC address of the interface.  Returns
-C<ifPhysAddress> for Ethernet interfaces and airespace_if_mac() for virtual 
+C<ifPhysAddress> for Ethernet interfaces and airespace_if_mac() for virtual
 interfaces.
 
 =item $airespace->i_vlan()
@@ -1751,7 +1751,7 @@ the interface iid.
 =item $airespace->fw_port()
 
 Returns reference to a hash, value being airespace_sta_mac() and
-airespace_sta_slot() combined to match the interface iid.  
+airespace_sta_slot() combined to match the interface iid.
 
 =item $airespace->fw_mac()
 

--- a/lib/SNMP/Info/Bridge.pm
+++ b/lib/SNMP/Info/Bridge.pm
@@ -189,7 +189,7 @@ sub qb_fw_vlan {
     foreach my $idx ( keys %$qb_fw_port ) {
         my ( $fdb_id, $mac ) = _qb_fdbtable_index($idx);
         # Many devices do not populate the dot1qVlanCurrentTable, so default
-        # to FDB ID = VID, but if we have a mapping use it.  
+        # to FDB ID = VID, but if we have a mapping use it.
         my $vlan = $fdb_id;
         # defined as test since some devices have a vlan 0
         if (defined $qb_fdb_ids->{$fdb_id}) {
@@ -237,7 +237,7 @@ sub qb_fdb_index {
     return $vl_fdb_index;
 }
 
-# Most devices now support Q-BRIDGE-MIB, fall back to 
+# Most devices now support Q-BRIDGE-MIB, fall back to
 # BRIDGE-MIB for those that don't.
 sub fw_mac {
     my $bridge = shift;
@@ -262,7 +262,7 @@ sub fw_status {
 
     my $qb = $bridge->qb_fw_status();
     return $qb if (ref {} eq ref $qb and scalar keys %$qb);
-    
+
     return $bridge->SUPER::fw_status();
 }
 
@@ -555,10 +555,10 @@ Max Baker
 
 =head1 SYNOPSIS
 
- my $bridge = new SNMP::Info ( 
+ my $bridge = new SNMP::Info (
                              AutoSpecify => 1,
                              Debug       => 1,
-                             DestHost    => 'switch', 
+                             DestHost    => 'switch',
                              Community   => 'public',
                              Version     => 2
                              );
@@ -579,7 +579,7 @@ Max Baker
     my $port  = $interfaces->{$iid};
 
     print "Port:$port forwarding to $mac\n";
- } 
+ }
 
 =head1 DESCRIPTION
 
@@ -588,12 +588,12 @@ MAC Forwarding Table and Spanning Tree Protocol info.
 
 F<Q-BRIDGE-MIB> holds 802.1q information -- VLANs and Trunking.  Cisco tends
 not to use this MIB, but some proprietary ones.  HP and some nicer vendors use
-this.  This is from C<RFC2674_q>.  
+this.  This is from C<RFC2674_q>.
 
 Create or use a subclass of SNMP::Info that inherits this class.  Do not use
 directly.
 
-For debugging you can call new() directly as you would in SNMP::Info 
+For debugging you can call new() directly as you would in SNMP::Info
 
  my $bridge = new SNMP::Info::Bridge(...);
 
@@ -657,19 +657,19 @@ Returns root of STP.
 
 (C<dot1dStpDesignatedRoot>)
 
-=item $bridge->qb_vlans_max() 
+=item $bridge->qb_vlans_max()
 
 Maximum number of VLANS supported on this device.
 
 (C<dot1qMaxSupportedVlans>)
 
-=item $bridge->qb_vlans() 
+=item $bridge->qb_vlans()
 
 Current number of VLANs that are configured in this device.
 
 (C<dot1qNumVlans>)
 
-=item $bridge->qb_next_vlan_index() 
+=item $bridge->qb_next_vlan_index()
 
 The next available value for C<dot1qVlanIndex> of a local VLAN entry in
 C<dot1qVlanStaticTable>
@@ -701,7 +701,7 @@ IDs.  These are the VLANs which are members of the egress list for the port.
   Example:
   my $interfaces = $bridge->interfaces();
   my $vlans      = $bridge->i_vlan_membership();
-  
+
   foreach my $iid (sort keys %$interfaces) {
     my $port = $interfaces->{$iid};
     my $vlan = join(',', sort(@{$vlans->{$iid}}));
@@ -731,7 +731,7 @@ Returns VLAN IDs
 
 =head2 Forwarding Table (C<dot1dTpFdbEntry>)
 
-=over 
+=over
 
 =item $bridge->fw_mac()
 
@@ -949,7 +949,7 @@ The set of ports which are assigned to the egress list for this VLAN.
 =item $bridge->qb_cv_untagged()
 
 The set of ports which should transmit egress packets for this VLAN as
-untagged. 
+untagged.
 
 (C<dot1qVlanCurrentUntaggedPorts>)
 
@@ -987,7 +987,7 @@ for this VLAN.
 =item $bridge->qb_v_untagged()
 
 The set of ports which should transmit egress packets for this VLAN as
-untagged. 
+untagged.
 
 (C<dot1qVlanStaticUntaggedPorts>)
 
@@ -1027,13 +1027,13 @@ Returns reference to hash of forwarding table entries status
 (C<dot1qTpFdbStatus>)
 
 =back
- 
+
 =head1 SET METHODS
 
 These are methods that provide SNMP set functionality for overridden methods
 or provide a simpler interface to complex set operations.  See
 L<SNMP::Info/"SETTING DATA VIA SNMP"> for general information on set
-operations. 
+operations.
 
 =over
 

--- a/lib/SNMP/Info/CDP.pm
+++ b/lib/SNMP/Info/CDP.pm
@@ -245,10 +245,10 @@ Max Baker
 
 =head1 SYNOPSIS
 
- my $cdp = new SNMP::Info ( 
+ my $cdp = new SNMP::Info (
                              AutoSpecify => 1,
                              Debug       => 1,
-                             DestHost    => 'router', 
+                             DestHost    => 'router',
                              Community   => 'public',
                              Version     => 2
                            );
@@ -274,7 +274,7 @@ Max Baker
 
 =head1 DESCRIPTION
 
-SNMP::Info::CDP is a subclass of SNMP::Info that provides an object oriented 
+SNMP::Info::CDP is a subclass of SNMP::Info that provides an object oriented
 interface to CDP information through SNMP.
 
 CDP is a Layer 2 protocol that supplies topology information of devices that
@@ -284,7 +284,7 @@ some HP devices.
 Create or use a device subclass that inherits this class.  Do not use
 directly.
 
-Each device implements a subset of the global and cache entries. 
+Each device implements a subset of the global and cache entries.
 Check the return value to see if that data is held by the device.
 
 =head2 Inherited Classes
@@ -309,7 +309,7 @@ These are methods that return scalar values from SNMP
 
 =item  $cdp->hasCDP()
 
-Is CDP is active in this device?  
+Is CDP is active in this device?
 
 Accounts for SNMP version 1 devices which may have CDP but not cdp_run()
 
@@ -328,13 +328,13 @@ Interval in seconds at which CDP messages are generated.
 
 =item $cdp->cdp_holdtime()
 
-Time in seconds that CDP messages are kept. 
+Time in seconds that CDP messages are kept.
 
 (C<cdpGlobalHoldTime>)
 
-=item  $cdp->cdp_gid() 
+=item  $cdp->cdp_gid()
 
-Returns CDP device ID.  
+Returns CDP device ID.
 
 This is the device id broadcast via CDP to other devices, and is what is
 retrieved from remote devices with $cdp->id().
@@ -355,9 +355,9 @@ to a hash.
 =item $cdp->cdp_capabilities()
 
 Returns Device Functional Capabilities.  Results are munged into an ascii
-binary string, MSB.  Each digit represents a bit from the table below from 
+binary string, MSB.  Each digit represents a bit from the table below from
 the CDP Capabilities Mapping to Smartport Type table within the
-Cisco Small Business 200 Series Smart Switch Administration Guide, 
+Cisco Small Business 200 Series Smart Switch Administration Guide,
 L<http://www.cisco.com/c/en/us/support/switches/small-business-200-series-smart-switches/products-maintenance-guides-list.html>:
 
 (Bit) - Description
@@ -407,7 +407,7 @@ C<CISCO-VTP-MIB::managementDomainName>
 
 (C<cdpCacheVTPMgmtDomain>)
 
-=item $cdp->cdp_duplex() 
+=item $cdp->cdp_duplex()
 
 Returns the port duplex status from remote devices.
 
@@ -424,7 +424,7 @@ Returns remote device id string
 Returns the mapping to the SNMP Interface Table.
 
 Note that a lot devices don't implement $cdp->cdp_index(),  So if it isn't
-around, we fake it. 
+around, we fake it.
 
 In order to map the cdp table entry back to the interfaces() entry, we
 truncate the last number off of it :
@@ -435,7 +435,7 @@ truncate the last number off of it :
 
   # if not, let's fake it
   my $cdp_ip       = $device->cdp_ip();
-    
+
   my %cdp_if
   foreach my $key (keys %$cdp_ip){
       $iid = $key;
@@ -443,13 +443,13 @@ truncate the last number off of it :
       $iid =~ s/\.\d+$//;
       $cdp_if{$key} = $iid;
   }
- 
+
   return \%cdp_if;
 
 
 =item $cdp->cdp_index()
 
-Returns the mapping to the SNMP2 Interface table for CDP Cache Entries. 
+Returns the mapping to the SNMP2 Interface table for CDP Cache Entries.
 
 Most devices don't implement this, so you probably want to use $cdp->cdp_if()
 instead.
@@ -471,9 +471,9 @@ Returns remote address
 
 (C<cdpCacheAddress>)
 
-=item $cdp->cdp_platform() 
+=item $cdp->cdp_platform()
 
-Returns remote platform id 
+Returns remote platform id
 
 (C<cdpCachePlatform>)
 
@@ -489,7 +489,7 @@ Returns remote address type received.  Usually IP.
 
 (C<cdpCacheAddressType>)
 
-=item $cdp->cdp_ver() 
+=item $cdp->cdp_ver()
 
 Returns remote hardware version
 
@@ -508,7 +508,7 @@ for decimal placement.
 
 (C<cdpCachePowerConsumption>)
 
-=item  $cdp->cdp_cap() 
+=item  $cdp->cdp_cap()
 
 Returns hash of arrays with each array containing the system capabilities
 supported by the remote system.  Possible elements in the array are

--- a/lib/SNMP/Info/CiscoAgg.pm
+++ b/lib/SNMP/Info/CiscoAgg.pm
@@ -100,14 +100,14 @@ SNMP::Info Developers
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $info = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $info->class();

--- a/lib/SNMP/Info/CiscoConfig.pm
+++ b/lib/SNMP/Info/CiscoConfig.pm
@@ -279,7 +279,7 @@ Justin Hunter, Eric Miller
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
 
     or die "Can't connect to DestHost.\n";
 
@@ -431,7 +431,7 @@ Table of Flash copy operation entries.
 These are methods that provide SNMP set functionality for overridden methods
 or provide a simpler interface to complex set operations.  See
 L<SNMP::Info/"SETTING DATA VIA SNMP"> for general information on set
-operations. 
+operations.
 
 =over
 
@@ -448,7 +448,7 @@ older procedure has been depreciated by Cisco and is utilized only to support
 devices running older code revisions.
 
  Example:
- $ciscoconfig->copy_run_tftp('1.2.3.4', 'myconfig') 
+ $ciscoconfig->copy_run_tftp('1.2.3.4', 'myconfig')
     or die "Couldn't save config. ",$ciscoconfig->error(1);
 
 =item $ciscoconfig->copy_run_start()

--- a/lib/SNMP/Info/CiscoConfig.pm
+++ b/lib/SNMP/Info/CiscoConfig.pm
@@ -336,10 +336,6 @@ These are methods that return scalar value from SNMP
 These are methods that return tables of information in the form of a reference
 to a hash.
 
-=over
-
-=back
-
 =head2 Config Copy Request Table  (C<ccCopyTable>)
 
 =over

--- a/lib/SNMP/Info/CiscoPortSecurity.pm
+++ b/lib/SNMP/Info/CiscoPortSecurity.pm
@@ -152,14 +152,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $cps = new SNMP::Info(
                         AutoSpecify => 1,
                         Debug       => 1,
                         DestHost    => 'myswitch',
                         Community   => 'public',
                         Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $cps->class();

--- a/lib/SNMP/Info/CiscoPortSecurity.pm
+++ b/lib/SNMP/Info/CiscoPortSecurity.pm
@@ -196,10 +196,6 @@ None.
 
 These are methods that return scalar values from SNMP
 
-=over
-
-=back
-
 =head2 F<CISCO-PORT-SECURITY-MIB> globals
 
 =over

--- a/lib/SNMP/Info/CiscoPower.pm
+++ b/lib/SNMP/Info/CiscoPower.pm
@@ -46,9 +46,9 @@ $VERSION = '3.64';
 
 %GLOBALS = ();
 
-%FUNCS = ( 
-    'cpeth_ent_phy'     => 'cpeExtPsePortEntPhyIndex', 
-    'peth_port_power'   => 'cpeExtPsePortPwrConsumption', 
+%FUNCS = (
+    'cpeth_ent_phy'     => 'cpeExtPsePortEntPhyIndex',
+    'peth_port_power'   => 'cpeExtPsePortPwrConsumption',
 );
 
 %MUNGE = ();
@@ -113,14 +113,14 @@ Bill Fenner
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $poe = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $poe->class();
@@ -176,7 +176,7 @@ Maps the C<pethPsePortTable> to C<ifIndex> by way of the F<ENTITY-MIB>.
 
 Power supplied by PoE ports, in milliwatts
 (C<cpeExtPsePortPwrConsumption>)
- 
+
 =back
 
 =head2 CDP Port table

--- a/lib/SNMP/Info/CiscoQOS.pm
+++ b/lib/SNMP/Info/CiscoQOS.pm
@@ -86,14 +86,14 @@ Alexander Hartmaier
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $qos = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $qos->class();
@@ -101,7 +101,7 @@ Alexander Hartmaier
 
 =head1 DESCRIPTION
 
-SNMP::Info::CiscoQOS is a subclass of SNMP::Info that provides 
+SNMP::Info::CiscoQOS is a subclass of SNMP::Info that provides
 information about a cisco device's QoS config.
 
 Use or create in a subclass of SNMP::Info.  Do not use directly.

--- a/lib/SNMP/Info/CiscoRTT.pm
+++ b/lib/SNMP/Info/CiscoRTT.pm
@@ -67,14 +67,14 @@ Alexander Hartmaier
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $rtt = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $rtt->class();
@@ -82,7 +82,7 @@ Alexander Hartmaier
 
 =head1 DESCRIPTION
 
-SNMP::Info::CiscoRTT is a subclass of SNMP::Info that provides 
+SNMP::Info::CiscoRTT is a subclass of SNMP::Info that provides
 information about a cisco device's RTT values.
 
 Use or create in a subclass of SNMP::Info.  Do not use directly.

--- a/lib/SNMP/Info/CiscoStack.pm
+++ b/lib/SNMP/Info/CiscoStack.pm
@@ -295,14 +295,14 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $ciscostats = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $ciscostats->class();
@@ -386,7 +386,7 @@ Returns a map to IID for ports that are physical ports, not vlans, etc.
 
 =item $stack->i_type()
 
-Crosses p_port() with p_type() and returns the results. 
+Crosses p_port() with p_type() and returns the results.
 
 Overrides with C<ifType> if p_type() isn't available.
 
@@ -425,7 +425,7 @@ C<portAdminSpeed>
 
     Example:
     my %if_map = reverse %{$stack->interfaces()};
-    $stack->set_i_speed_admin('auto', $if_map{'FastEthernet0/1'}) 
+    $stack->set_i_speed_admin('auto', $if_map{'FastEthernet0/1'})
         or die "Couldn't change port speed. ",$stack->error(1);
 
 =item $stack->set_i_duplex_admin(duplex, ifIndex)

--- a/lib/SNMP/Info/CiscoStack.pm
+++ b/lib/SNMP/Info/CiscoStack.pm
@@ -439,7 +439,7 @@ C<portAdminSpeed>
 
     Example:
     my %if_map = reverse %{$stack->interfaces()};
-    $stack->set_i_duplex_admin('auto', $if_map{'FastEthernet0/1'}) 
+    $stack->set_i_duplex_admin('auto', $if_map{'FastEthernet0/1'})
         or die "Couldn't change port duplex. ",$stack->error(1);
 
 =back

--- a/lib/SNMP/Info/CiscoStats.pm
+++ b/lib/SNMP/Info/CiscoStats.pm
@@ -88,7 +88,7 @@ $VERSION = '3.64';
 
     # CISCO-FLASH-MIB::ciscoFlashDeviceTable
     'cisco_flash_size' => 'ciscoFlashDeviceSize',
-    
+
     # CISCO-IMAGE-MIB
     'ci_images' => 'ciscoImageString',
 );
@@ -334,7 +334,7 @@ Eric Miller, Max Baker, Sam Stickland
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $ciscostats = new SNMP::Info(
                     AutoSpecify => 1,
                     Debug       => 1,
@@ -342,7 +342,7 @@ Eric Miller, Max Baker, Sam Stickland
                     DestHost    => 'myswitch',
                     Community   => 'public',
                     Version     => 2
-                    ) 
+                    )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $ciscostats->class();
@@ -351,7 +351,7 @@ Eric Miller, Max Baker, Sam Stickland
 =head1 DESCRIPTION
 
 SNMP::Info::CiscoStats is a subclass of SNMP::Info that provides cpu, memory,
-os and version information about Cisco Devices. 
+os and version information about Cisco Devices.
 
 Use or create in a subclass of SNMP::Info.  Do not use directly.
 
@@ -447,7 +447,7 @@ Tries to parse C<ROMMON> version from rom_id() string
 
 Current CPU usage in percent.
 
-C<1.3.6.1.4.1.9.2.1.56.0> = 
+C<1.3.6.1.4.1.9.2.1.56.0> =
 C<OLD-CISCO-CPU-MIB:avgBusyPer>
 
 =item $ciscostats->ios_cpu_1min()

--- a/lib/SNMP/Info/CiscoStpExtensions.pm
+++ b/lib/SNMP/Info/CiscoStpExtensions.pm
@@ -277,6 +277,19 @@ Carlos Vicente
 
 =head1 SYNOPSIS
 
+   my $ciscostpext = new SNMP::Info(
+                         AutoSpecify => 1,
+                         Debug       => 1,
+                         DestHost    => 'myswitch',
+                         Community   => 'public',
+                         Version     => 2
+                       )
+
+   or die "Can't connect to DestHost.\n";
+
+   my $class = $ciscostpext->class();
+   print " Using device sub class : $class\n";
+
 =head1 DESCRIPTION
 
 Create or use a subclass of SNMP::Info that inherits this class.  Do not use

--- a/lib/SNMP/Info/CiscoStpExtensions.pm
+++ b/lib/SNMP/Info/CiscoStpExtensions.pm
@@ -277,7 +277,7 @@ Carlos Vicente
 
 =head1 SYNOPSIS
 
-   my $ciscostpext = new SNMP::Info(
+   my $stpx = new SNMP::Info(
                          AutoSpecify => 1,
                          Debug       => 1,
                          DestHost    => 'myswitch',
@@ -287,7 +287,7 @@ Carlos Vicente
 
    or die "Can't connect to DestHost.\n";
 
-   my $class = $ciscostpext->class();
+   my $class = $stpx->class();
    print " Using device sub class : $class\n";
 
 =head1 DESCRIPTION
@@ -306,6 +306,14 @@ For debugging you can call new() directly as you would in SNMP::Info
 =item SNMP::Info
 
 =item SNMP::Info::Bridge
+
+=back
+
+=head2 Required MIBs
+
+=over
+
+=item F<CISCO-STP-EXTENSIONS-MIB>
 
 =back
 

--- a/lib/SNMP/Info/CiscoStpExtensions.pm
+++ b/lib/SNMP/Info/CiscoStpExtensions.pm
@@ -1,29 +1,29 @@
 # SNMP::Info::CiscoStpExtensions
 #
 # Copyright (c)2009 Carlos Vicente
-# All rights reserved.  
+# All rights reserved.
 #
-# Redistribution and use in source and binary forms, with or without 
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 #     * Redistributions of source code must retain the above copyright notice,
 #       this list of conditions and the following disclaimer.
 #     * Redistributions in binary form must reproduce the above copyright notice,
 #       this list of conditions and the following disclaimer in the documentation
 #       and/or other materials provided with the distribution.
-#     * Neither the name of the author nor the 
-#       names of its contributors may be used to endorse or promote products 
+#     * Neither the name of the author nor the
+#       names of its contributors may be used to endorse or promote products
 #       derived from this software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 # DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
 # ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
 # LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package SNMP::Info::CiscoStpExtensions;
@@ -106,11 +106,11 @@ sub mst_region_rev {
 
 sub mst_vlan2instance {
     my $self = shift;
-    
+
     # Get MST vlan-to-instance mapping
     my $m1k2k = $self->stpx_smst_vlans_mapped_1k2k;
     my $m3k4k = $self->stpx_smst_vlans_mapped_3k4k;
-   
+
     # Get list of VLANs
     my $vlan_membership = $self->i_vlan_membership;
     my @vlans;
@@ -140,7 +140,7 @@ sub mst_vlan2instance {
                     $res{$vlan} = $inst;
                     last;
                 }
-            }       
+            }
         }
     }
     return \%res;
@@ -162,7 +162,7 @@ sub i_rootguard_enabled {
         $res{$iid} = $enabled;
     }
     return \%res;
-}  
+}
 
 sub i_loopguard_enabled {
     my $self    = shift;
@@ -180,7 +180,7 @@ sub i_loopguard_enabled {
         $res{$iid} = $enabled;
     }
     return \%res;
-}  
+}
 
 sub i_bpduguard_enabled {
     my $self    = shift;
@@ -189,7 +189,7 @@ sub i_bpduguard_enabled {
     my $bpdugm_default = $self->stpx_bpduguard_enable();
     my $bp_index       = $self->bp_index($partial);
     my $bpdugm         = $self->stpx_port_bpduguard_mode();
-    
+
     my %res;
     foreach my $index ( keys %$bpdugm ){
         my $mode = $bpdugm->{$index};
@@ -212,7 +212,7 @@ sub i_bpdufilter_enabled {
     my $bpdufm_default = $self->stpx_bpdufilter_enable();
     my $bp_index       = $self->bp_index($partial);
     my $bpdufm         = $self->stpx_port_bpdufilter_mode();
-    
+
     my %res;
     foreach my $index ( keys %$bpdufm ){
         my $mode = $bpdufm->{$index};
@@ -295,7 +295,7 @@ Carlos Vicente
 Create or use a subclass of SNMP::Info that inherits this class.  Do not use
 directly.
 
-For debugging you can call new() directly as you would in SNMP::Info 
+For debugging you can call new() directly as you would in SNMP::Info
 
  my $stpx = new SNMP::Info::CiscoStpExtensions(...);
 
@@ -303,9 +303,9 @@ For debugging you can call new() directly as you would in SNMP::Info
 
 =over
 
-=item SNMP::Info 
+=item SNMP::Info
 
-=item SNMP::Info::Bridge 
+=item SNMP::Info::Bridge
 
 =back
 
@@ -319,7 +319,7 @@ These are methods that return scalar values from SNMP
 
 =item $stpx->stp_ver()
 
-Returns the particular STP version running on this device.  
+Returns the particular STP version running on this device.
 Meant to override SNMP::Info::Brigde::stp_ver()
 
 Values: C<pvstPlus>, C<mistp>, C<mistpPvstPlus>, C<mst>, C<rapidPvstPlus>
@@ -337,25 +337,25 @@ to a hash.
 
 =item $stpx->mst_config_digest()
 
-Returns the Multiple Spanning Tree (MST) configuration digest 
+Returns the Multiple Spanning Tree (MST) configuration digest
 
 (C<stpxSMSTConfigDigest>)
 
 =item $stpx->mst_region_name()
 
-Returns the Multiple Spanning Tree (MST) region name 
+Returns the Multiple Spanning Tree (MST) region name
 
 (C<stpxMSTRegionName>)
 
 =item $stpx->mst_region_rev()
 
-Returns the Multiple Spanning Tree (MST) region name 
+Returns the Multiple Spanning Tree (MST) region name
 
 (C<stpxSMSTRegionRevision>)
 
 =item $stpx->mst_vlan2instance()
 
-Returns the mapping of vlan to MST instance in the form of a hash reference 
+Returns the mapping of vlan to MST instance in the form of a hash reference
 with key = VLAN id, value = STP instance
 
 =item $stpx->i_rootguard_enabled()

--- a/lib/SNMP/Info/CiscoVTP.pm
+++ b/lib/SNMP/Info/CiscoVTP.pm
@@ -172,7 +172,7 @@ sub i_vlan {
         # vtp_trunk_dyn_stat is not useful for down ports
         # so we use vtp_trunk_dyn to see if trunking is set
         my $dyn = $trunk_dyn->{$port};
-        
+
         if (($stat and $stat =~ /^trunking/ )
             or ($dyn and (($dyn eq 'on') or ($dyn eq 'onNoNegotiate'))))
         {
@@ -303,7 +303,7 @@ sub i_vlan_membership_untagged {
         my $vlan = $vlans->{$port};
         push( @{ $i_vlan_membership->{$port} }, $vlan );
     }
-    
+
     return $i_vlan_membership;
 }
 
@@ -529,14 +529,14 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $vtp = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $vtp->class();
@@ -544,7 +544,7 @@ Max Baker
 
 =head1 DESCRIPTION
 
-SNMP::Info::CiscoVTP is a subclass of SNMP::Info that provides 
+SNMP::Info::CiscoVTP is a subclass of SNMP::Info that provides
 information about a Cisco device's VLAN and VTP Domain membership.
 
 Use or create in a subclass of SNMP::Info.  Do not use directly.
@@ -620,7 +620,7 @@ IDs.  These are the VLANs which are members of enabled VLAN list for the port.
   Example:
   my $interfaces = $vtp->interfaces();
   my $vlans      = $vtp->i_vlan_membership();
-  
+
   foreach my $iid (sort keys %$interfaces) {
     my $port = $interfaces->{$iid};
     my $vlan = join(',', sort(@{$vlans->{$iid}}));
@@ -722,7 +722,7 @@ for a good treaty of how to connect to the VLANs
 
 =item $vtp->i_vlan_type()
 
-Static, Dynamic, or multiVlan.  
+Static, Dynamic, or multiVlan.
 
 (C<vmVlanType>)
 
@@ -769,7 +769,7 @@ Each bit represents a VLAN.  This is 3072 through 4095
 
 =over
 
-=item $vtp->i_voice_vlan() 
+=item $vtp->i_voice_vlan()
 
 (C<vmVoiceVlanId>)
 
@@ -884,7 +884,7 @@ Each bit represents a VLAN.  This is 3072 through 4095
 These are methods that provide SNMP set functionality for overridden methods
 or provide a simpler interface to complex set operations.  See
 L<SNMP::Info/"SETTING DATA VIA SNMP"> for general information on set
-operations. 
+operations.
 
 =over
 
@@ -896,7 +896,7 @@ VLAN ID and port C<ifIndex>.  This method should only be used on end station
 
   Example:
   my %if_map = reverse %{$vtp->interfaces()};
-  $vtp->set_i_vlan('2', $if_map{'FastEthernet0/1'}) 
+  $vtp->set_i_vlan('2', $if_map{'FastEthernet0/1'})
     or die "Couldn't change port VLAN. ",$vtp->error(1);
 
 =item $vtp->set_i_pvid ( pvid, ifIndex )
@@ -906,7 +906,7 @@ port C<ifIndex>.  This method should only be used on trunk ports.
 
   Example:
   my %if_map = reverse %{$vtp->interfaces()};
-  $vtp->set_i_pvid('2', $if_map{'FastEthernet0/1'}) 
+  $vtp->set_i_pvid('2', $if_map{'FastEthernet0/1'})
     or die "Couldn't change port default VLAN. ",$vtp->error(1);
 
 =item $vtp->set_i_untagged ( vlan, ifIndex )
@@ -922,7 +922,7 @@ numeric VLAN ID and port C<ifIndex>.
 
   Example:
   my %if_map = reverse %{$vtp->interfaces()};
-  $vtp->set_add_i_vlan_tagged('2', $if_map{'FastEthernet0/1'}) 
+  $vtp->set_add_i_vlan_tagged('2', $if_map{'FastEthernet0/1'})
     or die "Couldn't add port to egress list. ",$vtp->error(1);
 
 =item $vtp->set_remove_i_vlan_tagged ( vlan, ifIndex )
@@ -932,7 +932,7 @@ with the numeric VLAN ID and port C<ifIndex>.
 
   Example:
   my %if_map = reverse %{$vtp->interfaces()};
-  $vtp->set_remove_i_vlan_tagged('2', $if_map{'FastEthernet0/1'}) 
+  $vtp->set_remove_i_vlan_tagged('2', $if_map{'FastEthernet0/1'})
     or die "Couldn't add port to egress list. ",$vtp->error(1);
 
 =back

--- a/lib/SNMP/Info/EDP.pm
+++ b/lib/SNMP/Info/EDP.pm
@@ -64,7 +64,7 @@ sub hasEDP {
     my $edp_ip = $edp->extremeEdpNeighborVlanIpAddress() || {};
 
     return 1 if ( scalar( keys %$edp_ip ) );
-    
+
     return;
 }
 
@@ -80,7 +80,7 @@ sub _edp_index {
     my $edp = shift;
 
     my $edp_ip  = $edp->extremeEdpNeighborVlanIpAddress() || {};
-    
+
     my %edp_index;
     foreach my $key ( keys %$edp_ip ) {
         my $ip = $edp_ip->{$key};
@@ -103,7 +103,7 @@ sub edp_if {
         $iid = $1 if $iid =~ /^(\d+)\./;
         $edp_if{$key} = $iid;
     }
- 
+
   return \%edp_if;
 }
 
@@ -193,10 +193,10 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- my $edp = new SNMP::Info ( 
+ my $edp = new SNMP::Info (
                              AutoSpecify => 1,
                              Debug       => 1,
-                             DestHost    => 'router', 
+                             DestHost    => 'router',
                              Community   => 'public',
                              Version     => 2
                            );
@@ -222,7 +222,7 @@ Eric Miller
 
 =head1 DESCRIPTION
 
-SNMP::Info::EDP is a subclass of SNMP::Info that provides an object oriented 
+SNMP::Info::EDP is a subclass of SNMP::Info that provides an object oriented
 interface to EDP information through SNMP.
 
 EDP is a Layer 2 protocol that allows a network device to advertise its
@@ -251,7 +251,7 @@ These are methods that return scalar values from SNMP
 
 =item $edp->hasEDP()
 
-Is EDP is active in this device?  
+Is EDP is active in this device?
 
 =back
 
@@ -285,7 +285,7 @@ Returns remote port ID
 
 Returns the operating system version of the remote system.
 
-Nulls are removed before the value is returned. 
+Nulls are removed before the value is returned.
 
 (C<extremeEdpNeighborSoftwareVersion>)
 

--- a/lib/SNMP/Info/Entity.pm
+++ b/lib/SNMP/Info/Entity.pm
@@ -174,14 +174,14 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $entity = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $entity->class();

--- a/lib/SNMP/Info/EtherLike.pm
+++ b/lib/SNMP/Info/EtherLike.pm
@@ -95,14 +95,14 @@ Max Baker
 
 =head1 SYNOPSIS
 
- my $el = new SNMP::Info ( 
+ my $el = new SNMP::Info (
                              AutoSpecify => 1,
                              Debug       => 1,
-                             DestHost    => 'router', 
+                             DestHost    => 'router',
                              Community   => 'public',
                              Version     => 2
                            );
- 
+
  my $class = $cdp->class();
  print " Using device sub class : $class\n";
 
@@ -110,7 +110,7 @@ Max Baker
  # ETHERLIKE-MIB
  my $interfaces = $el->interfaces();
  my $el_index   = $el->el_index();
- my $el_duplex  = $el->el_duplex(); 
+ my $el_duplex  = $el->el_duplex();
 
  foreach my $el_port (keys %$el_duplex){
     my $duplex = $el_duplex->{$el_port};
@@ -122,7 +122,7 @@ Max Baker
 
 =head1 DESCRIPTION
 
-SNMP::Info::EtherLike is a subclass of SNMP::Info that supplies 
+SNMP::Info::EtherLike is a subclass of SNMP::Info that supplies
 access to the F<ETHERLIKE-MIB> used by some Layer 3 Devices such as
 Cisco routers.
 
@@ -133,7 +133,7 @@ directly.
 
 =head2 Inherited Classes
 
-None.  
+None.
 
 =head2 Required MIBs
 

--- a/lib/SNMP/Info/FDP.pm
+++ b/lib/SNMP/Info/FDP.pm
@@ -132,10 +132,10 @@ Bruce Rodger, Max Baker
 
 =head1 SYNOPSIS
 
- my $fdp = new SNMP::Info ( 
+ my $fdp = new SNMP::Info (
                              AutoSpecify => 1,
                              Debug       => 1,
-                             DestHost    => 'router', 
+                             DestHost    => 'router',
                              Community   => 'public',
                              Version     => 2
                            );
@@ -161,7 +161,7 @@ Bruce Rodger, Max Baker
 
 =head1 DESCRIPTION
 
-SNMP::Info::FDP is a subclass of SNMP::Info that provides an object oriented 
+SNMP::Info::FDP is a subclass of SNMP::Info that provides an object oriented
 interface to FDP information through SNMP.
 
 FDP is a Layer 2 protocol that supplies topology information of
@@ -172,7 +172,7 @@ virtually identical.  FDP is implemented in Brocade (Foundry) devices.
 Create or use a device subclass that inherits this class.  Do not use
 directly.
 
-Each device implements a subset of the global and cache entries. 
+Each device implements a subset of the global and cache entries.
 Check the return value to see if that data is held by the device.
 
 =head2 Inherited Classes
@@ -186,7 +186,7 @@ None.
 =item F<FOUNDRY-SN-SWITCH-GROUP-MIB>
 
 Needs a reasonably recent MIB. Works OK with B2R07604A.mib, but doesn't
-work with B2R07600C. 
+work with B2R07600C.
 
 =back
 
@@ -198,13 +198,13 @@ These are methods that return scalar values from SNMP
 
 =item  $fdp->hasFDP()
 
-Is FDP is active in this device?  
+Is FDP is active in this device?
 
 Accounts for SNMP version 1 devices which may have FDP but not fdp_run()
 
 =item $fdp->fdp_run()
 
-Is FDP enabled on this device?  
+Is FDP enabled on this device?
 
 (C<fdpGlobalRun>)
 
@@ -216,7 +216,7 @@ Interval in seconds at which FDP messages are generated.
 
 =item $fdp->fdp_holdtime()
 
-Time in seconds that FDP messages are kept. 
+Time in seconds that FDP messages are kept.
 
 (C<fdpGlobalHoldTime>)
 
@@ -236,13 +236,13 @@ Interval in seconds at which FDP messages are generated.
 
 =item $fdp->fdp_holdtime()
 
-Time in seconds that FDP messages are kept. 
+Time in seconds that FDP messages are kept.
 
 (C<fdpGlobalHoldTime>)
 
-=item  $fdp->fdp_id() 
+=item  $fdp->fdp_id()
 
-Returns FDP device ID.  
+Returns FDP device ID.
 
 This is the device id broadcast via FDP to other devices, and is what is
 retrieved from remote devices with $fdp->id().
@@ -334,9 +334,9 @@ Returns remote IP address
 
 (C<fdpCacheAddress>)
 
-=item $fdp->fdp_platform() 
+=item $fdp->fdp_platform()
 
-Returns remote platform id 
+Returns remote platform id
 
 (C<fdpCachePlatform>)
 
@@ -352,13 +352,13 @@ Returns remote address type received.  Usually IP.
 
 (C<fdpCacheAddressType>)
 
-=item $fdp->fdp_ver() 
+=item $fdp->fdp_ver()
 
 Returns remote hardware version
 
 (C<fdpCacheVersion>)
 
-=item $fdp->fdp_cache_type() 
+=item $fdp->fdp_cache_type()
 
 Returns type of entry received, either FDP or CDP.
 

--- a/lib/SNMP/Info/IEEE802dot11.pm
+++ b/lib/SNMP/Info/IEEE802dot11.pm
@@ -203,7 +203,7 @@ Eric Miller
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
 
     or die "Can't connect to DestHost.\n";
 

--- a/lib/SNMP/Info/IEEE802dot3ad.pm
+++ b/lib/SNMP/Info/IEEE802dot3ad.pm
@@ -82,10 +82,10 @@ sub agg_ports_lag {
     for ( my $i = 0; $i <= scalar(@$portlist); $i++ ) {
       my $ifindex = $i+1;
       if ( exists($index->{$i+1}) and defined($index->{$i+1}) ) {
-        $ifindex = $index->{$i+1};       
+        $ifindex = $index->{$i+1};
       }
       $ret->{$ifindex} = $idx if ( @$portlist[$i] );
-    }   
+    }
   }
 
   return $ret;
@@ -105,14 +105,14 @@ SNMP::Info Developers
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $info = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $info->class();

--- a/lib/SNMP/Info/IPv6.pm
+++ b/lib/SNMP/Info/IPv6.pm
@@ -48,15 +48,15 @@ $VERSION = '3.64';
 
 
 
-%MIBS = ( 
+%MIBS = (
     'IP-MIB'            => 'ipv6InterfaceTableLastChange',
     'IPV6-MIB'          => 'ipv6IfTableLastChange',
-    'CISCO-IETF-IP-MIB' => 'cInetNetToMediaNetAddress', 
+    'CISCO-IETF-IP-MIB' => 'cInetNetToMediaNetAddress',
 );
 
 %GLOBALS = ();
 
-%FUNCS = ( 
+%FUNCS = (
     'ip_n2p_phys_addr'  => 'ipNetToPhysicalPhysAddress',    # IP-MIB
     'c_inet_phys_addr'  => 'cInetNetToMediaPhysAddress',    # CISCO-IETF-IP-MIB
     'i6_n2p_phys_addr'  => 'ipv6NetToMediaPhysAddress',     # IPV6-MIB
@@ -70,10 +70,10 @@ $VERSION = '3.64';
     'i6_n2p_phys_state' => 'ipv6IfNetToMediaState',         # IPV6-MIB
 
     'ip_pfx_origin'     => 'ipAddressPrefixOrigin',         # IP-MIB
-    'c_pfx_origin'      => 'cIpAddressPfxOrigin',           # CISCO-IETF-IP-MIB 
+    'c_pfx_origin'      => 'cIpAddressPfxOrigin',           # CISCO-IETF-IP-MIB
 
     'ip_addr6_pfx'      => 'ipAddressPrefix',               # IP-MIB
-    'c_addr6_pfx'       => 'cIpAddressPrefix',              # CISCO-IETF-IP-MIB 
+    'c_addr6_pfx'       => 'cIpAddressPrefix',              # CISCO-IETF-IP-MIB
 
     # Commented out are not-accessible according to MIB
     #'ip_addr6_pfxlen'   => 'ipAddressPrefixLength',        # IP-MIB
@@ -81,7 +81,7 @@ $VERSION = '3.64';
     'i6_addr_pfxlen'    => 'ipv6AddrPfxLength',             # IPV6-MIB
 
     'ip_addr6_index'    => 'ipAddressIfIndex',              # IP-MIB
-    'c_addr6_index'     => 'cIpAddressIfIndex',             # CISCO-IETF-IP-MIB 
+    'c_addr6_index'     => 'cIpAddressIfIndex',             # CISCO-IETF-IP-MIB
 
     'ip_addr6_type'     => 'ipAddressType',                 # IP-MIB
     'c_addr6_type'      => 'cIpAddressType',                # CISCO-IETF-IP-MIB
@@ -106,8 +106,8 @@ sub ipv6_n2p_mac {
     foreach my $row (keys %$phys_addr) {
         if ($row =~ /^(\d+)\.(\d+)\.(\d+)\.([\d\.]+)$/) {
             my $ifindex = $1; my $addrtype = $2; my $addrsize = $3; my $v6addr = $4;
-            if ($info::METHOD == IPV6MIB) { 
-                # IPV6-MIB doesn't include the addrtype in the index; 
+            if ($info::METHOD == IPV6MIB) {
+                # IPV6-MIB doesn't include the addrtype in the index;
                 # also, address syntax is IPv6Address (fixed 16 bytes) and not InetAddress (length field followed by address bytes)
                 $v6addr = join('.', $addrtype, $addrsize, $v6addr);
                 $addrtype = 2;
@@ -133,8 +133,8 @@ sub ipv6_n2p_addr {
     foreach my $row (keys %$net_addr) {
         if ($row =~ /^(\d+)\.(\d+)\.(\d+)\.([\d\.]+)$/) {
             my $ifindex = $1; my $addrtype = $2; my $addrsize = $3; my $v6addr = $4;
-            if ($info::METHOD == IPV6MIB) { 
-                # IPV6-MIB doesn't include the addrtype in the index; 
+            if ($info::METHOD == IPV6MIB) {
+                # IPV6-MIB doesn't include the addrtype in the index;
                 # also, address syntax is IPv6Address (fixed 16 bytes) and not InetAddress (length field followed by address bytes)
                 $v6addr = join('.', $addrtype, $addrsize, $v6addr);
                 $addrtype = 2;
@@ -142,7 +142,7 @@ sub ipv6_n2p_addr {
             if ($addrtype == 2) { # IPv6
                 my $v6_packed = pack("C*", split(/\./, $v6addr));
                 if (length($v6_packed) == 15) {
-                    # Workaround for some some IP-MIB implementations, eg on Cisco Nexus: no explicit addrsize, 
+                    # Workaround for some some IP-MIB implementations, eg on Cisco Nexus: no explicit addrsize,
                     # so what we've collected in that variable is actually the first byte of the address.
                     $v6_packed = pack('C', $addrsize) . $v6_packed;
                 }
@@ -177,8 +177,8 @@ sub ipv6_n2p_if {
     foreach my $row (keys %$phys_addr) {
         if ($row =~ /^(\d+)\.(\d+)\.(\d+)\.([\d\.]+)$/) {
             my $ifindex = $1; my $addrtype = $2; my $addrsize = $3; my $v6addr = $4;
-            if ($info::METHOD == IPV6MIB) { 
-                # IPV6-MIB doesn't include the addrtype in the index; 
+            if ($info::METHOD == IPV6MIB) {
+                # IPV6-MIB doesn't include the addrtype in the index;
                 # also, address syntax is IPv6Address (fixed 16 bytes) and not InetAddress (length field followed by address bytes)
                 $v6addr = join('.', $addrtype, $addrsize, $v6addr);
                 $addrtype = 2;
@@ -204,8 +204,8 @@ sub ipv6_n2p_type {
     foreach my $row (keys %$phys_type) {
         if ($row =~ /^(\d+)\.(\d+)\.(\d+)\.([\d\.]+)$/) {
             my $ifindex = $1; my $addrtype = $2; my $addrsize = $3; my $v6addr = $4;
-            if ($info::METHOD == IPV6MIB) { 
-                # IPV6-MIB doesn't include the addrtype in the index; 
+            if ($info::METHOD == IPV6MIB) {
+                # IPV6-MIB doesn't include the addrtype in the index;
                 # also, address syntax is IPv6Address (fixed 16 bytes) and not InetAddress (length field followed by address bytes)
                 $v6addr = join('.', $addrtype, $addrsize, $v6addr);
                 $addrtype = 2;
@@ -231,8 +231,8 @@ sub ipv6_n2p_state {
     foreach my $row (keys %$phys_state) {
         if ($row =~ /^(\d+)\.(\d+)\.(\d+)\.([\d\.]+)$/) {
             my $ifindex = $1; my $addrtype = $2; my $addrsize = $3; my $v6addr = $4;
-            if ($info::METHOD == IPV6MIB) { 
-                # IPV6-MIB doesn't include the addrtype in the index; 
+            if ($info::METHOD == IPV6MIB) {
+                # IPV6-MIB doesn't include the addrtype in the index;
                 # also, address syntax is IPv6Address (fixed 16 bytes) and not InetAddress (length field followed by address bytes)
                 $v6addr = join('.', $addrtype, $addrsize, $v6addr);
                 $addrtype = 2;
@@ -442,14 +442,14 @@ Jeroen van Ingen and Carlos Vicente
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $info = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $info->class();
@@ -457,12 +457,12 @@ Jeroen van Ingen and Carlos Vicente
 
 =head1 DESCRIPTION
 
-The SNMP::Info::IPv6 class implements functions to for mapping IPv6 addresses 
+The SNMP::Info::IPv6 class implements functions to for mapping IPv6 addresses
 to MAC addresses, interfaces and more. It will use data from the F<IP-MIB>,
 F<IPV6-MIB>, or the F<CISCO-IETF-IP-MIB>, whichever is supported by the
 device.
 
-This class is inherited by Info::Layer3 to provide IPv6 node tracking across  
+This class is inherited by Info::Layer3 to provide IPv6 node tracking across
 device classes.
 
 For debugging purposes you can call this class directly as you would
@@ -519,7 +519,7 @@ Maps an IPv6 address to its type (unicast, anycast, etc.)
 
 Maps an IPv6 prefix with its origin (manual, well-known, dhcp, etc.)
 
-=item $info->ipv6_addr_prefix() 
+=item $info->ipv6_addr_prefix()
 
 Maps IPv6 addresses with their prefixes
 
@@ -545,7 +545,7 @@ Maps an address of type C<cInetNetToMediaNetAddressType> on interface C<ifIndex>
 
 =head1 MUNGES
 
-=over 
+=over
 
 =item munge_physaddr()
 

--- a/lib/SNMP/Info/LLDP.pm
+++ b/lib/SNMP/Info/LLDP.pm
@@ -141,7 +141,7 @@ sub lldp_if {
         next unless $port;
 
         # Local LLDP port may not equate to ifIndex, see LldpPortNumber
-        # TEXTUAL-CONVENTION in LLDP-MIB. Cross reference lldpLocPortDesc 
+        # TEXTUAL-CONVENTION in LLDP-MIB. Cross reference lldpLocPortDesc
         # with ifDescr and ifAlias to get ifIndex, prefer ifDescr over
         # ifAlias because using cross ref with description is correct
         # behavior according to the LLDP-MIB. Some devices (eg H3C gear)
@@ -455,10 +455,10 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- my $lldp = new SNMP::Info ( 
+ my $lldp = new SNMP::Info (
                              AutoSpecify => 1,
                              Debug       => 1,
-                             DestHost    => 'router', 
+                             DestHost    => 'router',
                              Community   => 'public',
                              Version     => 2
                            );
@@ -484,7 +484,7 @@ Eric Miller
 
 =head1 DESCRIPTION
 
-SNMP::Info::LLDP is a subclass of SNMP::Info that provides an object oriented 
+SNMP::Info::LLDP is a subclass of SNMP::Info that provides an object oriented
 interface to LLDP information through SNMP.
 
 LLDP is a Layer 2 protocol that allows a network device to advertise its
@@ -520,7 +520,7 @@ These are methods that return scalar values from SNMP
 
 =item $lldp->hasLLDP()
 
-Is LLDP is active in this device?  
+Is LLDP is active in this device?
 
 Note:  LLDP may be active, but nothing in C<lldpRemoteSystemsData> Tables so
 the device would not return any useful topology information.
@@ -531,7 +531,7 @@ The string value used to identify the system name of the local system.  If the
 local agent supports IETF RFC 3418, C<lldpLocSysName> object should have the
 same value of C<sysName> object.
 
-Nulls are removed before the value is returned. 
+Nulls are removed before the value is returned.
 
 (C<lldpLocSysName>)
 
@@ -545,7 +545,7 @@ Nulls are removed before the value is returned.
 
 (C<lldpLocSysDesc>)
 
-=item  $lldp->lldp_sys_cap() 
+=item  $lldp->lldp_sys_cap()
 
 Returns which system capabilities are enabled on the local system.  Results
 are munged into an ascii binary string, LSB.  Each digit represents a bit
@@ -595,8 +595,8 @@ with the remote system.
 
 =item $lldp->lldp_if()
 
-Returns the mapping to the SNMP Interface Table. Tries to cross reference 
-(C<lldpLocPortDesc>) with (C<ifDescr>) and (C<ifAlias>) to get (C<ifIndex>), 
+Returns the mapping to the SNMP Interface Table. Tries to cross reference
+(C<lldpLocPortDesc>) with (C<ifDescr>) and (C<ifAlias>) to get (C<ifIndex>),
 if unable defaults to (C<lldpRemLocalPortNum>).
 
 =item  $lldp->lldp_ip()
@@ -611,7 +611,7 @@ use lldp_addr if you don't care about return address type.
 
 =item  $lldp->lldp_mac()
 
-Returns remote (management) MAC address, if known.  Returns for all other 
+Returns remote (management) MAC address, if known.  Returns for all other
 address types, use lldp_addr if you don't care about return address type.
 
 =item  $lldp->lldp_addr()
@@ -632,13 +632,13 @@ Returns remote port ID
 Tries to return something useful from C<lldp_rem_sysdesc()> or
 C<lldp_rem_sysname()>.
 
-=item  $lldp->lldp_cap() 
+=item  $lldp->lldp_cap()
 
 Returns hash of arrays with each array containing the system capabilities
 supported by the remote system.  Possible elements in the array are
 enumerated from C<LldpSystemCapabilitiesMap>.
 
-=item  $lldp->lldp_media_cap() 
+=item  $lldp->lldp_media_cap()
 
 Returns hash of arrays with each array containing the media capabilities
 supported by the remote system.  Possible elements in the array are
@@ -683,7 +683,7 @@ the remote system.
 Returns the string value used to identify the description of the given port
 associated with the remote system.
 
-Nulls are removed before the value is returned. 
+Nulls are removed before the value is returned.
 
 (C<lldpRemPortDesc>)
 
@@ -692,7 +692,7 @@ Nulls are removed before the value is returned.
 Returns the string value used to identify the system name of the remote
 system.
 
-Nulls are removed before the value is returned. 
+Nulls are removed before the value is returned.
 
 (C<lldpRemSysName>)
 
@@ -701,70 +701,70 @@ Nulls are removed before the value is returned.
 Returns the string value used to identify the system description of the
 remote system.
 
-Nulls are removed before the value is returned. 
+Nulls are removed before the value is returned.
 
 (C<lldpRemSysDesc>)
 
 =item $lldp->lldp_rem_hw_rev()
 
 Returns the string value used to identify the hardware revision of the
-remote system. Nulls are removed before the value is returned. 
+remote system. Nulls are removed before the value is returned.
 
 (C<lldpXMedRemHardwareRev>)
 
 =item $lldp->lldp_rem_fw_rev()
 
 Returns the string value used to identify the firmware revision of the
-remote system. Nulls are removed before the value is returned. 
+remote system. Nulls are removed before the value is returned.
 
 (C<lldpXMedRemHardwareRev>)
 
 =item $lldp->lldp_rem_sw_rev()
 
 Returns the string value used to identify the software revision of the
-remote system. Nulls are removed before the value is returned. 
+remote system. Nulls are removed before the value is returned.
 
 (C<lldpXMedRemSoftwareRev>)
 
 =item $lldp->lldp_rem_serial()
 
 Returns the string value used to identify the serial number of the
-remote system. Nulls are removed before the value is returned. 
+remote system. Nulls are removed before the value is returned.
 
 (C<lldpXMedRemSerialNum>)
 
 =item $lldp->lldp_rem_vendor()
 
 Returns the string value used to identify the manufacturer of the
-remote system. Nulls are removed before the value is returned. 
+remote system. Nulls are removed before the value is returned.
 
 (C<lldpXMedRemMfgName>)
 
 =item $lldp->lldp_rem_asset()
 
 Returns the string value used to identify the asset number of the
-remote system. Nulls are removed before the value is returned. 
+remote system. Nulls are removed before the value is returned.
 
 (C<lldpXMedRemAssetID>)
 
 =item $lldp->lldp_rem_model()
 
 Returns the string value used to identify the model of the
-remote system. Nulls are removed before the value is returned. 
+remote system. Nulls are removed before the value is returned.
 
 (C<lldpXMedRemModelName>)
 
-=item  $lldp->lldp_rem_media_cap_spt() 
+=item  $lldp->lldp_rem_media_cap_spt()
 
 Returns which media capabilities are supported on the remote system. Results
 are munged into an ascii binary string, LSB.
 
-=item  $lldp->lldp_rem_media_cap() 
+=item  $lldp->lldp_rem_media_cap()
 
 Returns which media capabilities are enabled on the remote system. Results
 are munged into an ascii binary string, LSB.
 
-=item  $lldp->lldp_rem_sys_cap() 
+=item  $lldp->lldp_rem_sys_cap()
 
 Returns which system capabilities are enabled on the remote system.  Results
 are munged into an ascii binary string, LSB.  Each digit represents a bit

--- a/lib/SNMP/Info/Layer1.pm
+++ b/lib/SNMP/Info/Layer1.pm
@@ -172,14 +172,14 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $l1 = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 1
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $l1->class();
@@ -203,15 +203,15 @@ This class is usually used as a superclass for more specific device classes
 listed under SNMP::Info::Layer1::*   Please read all docs under SNMP::Info
 first.
 
-Provides abstraction to the configuration information obtainable from a 
+Provides abstraction to the configuration information obtainable from a
 Layer1 device through SNMP.  Information is stored in a number of MIBs.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $l1 = new SNMP::Info::Layer1(...);
 
-=head2 Inherited Classes 
+=head2 Inherited Classes
 
 =over
 
@@ -219,7 +219,7 @@ after determining a more specific class using the method above.
 
 =back
 
-=head2 Required MIBs 
+=head2 Required MIBs
 
 =over
 
@@ -242,7 +242,7 @@ These are methods that return scalar value from SNMP
 
 =item $l1->ports_managed()
 
-Gets the number of ports under the interface mib 
+Gets the number of ports under the interface mib
 
 (C<ifNumber>)
 

--- a/lib/SNMP/Info/Layer1/Allied.pm
+++ b/lib/SNMP/Info/Layer1/Allied.pm
@@ -128,14 +128,14 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $allied = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myhub',
                           Community   => 'public',
                           Version     => 1
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $allied->class();
@@ -143,8 +143,8 @@ Max Baker
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from a 
-Allied device through SNMP. See inherited classes' documentation for 
+Provides abstraction to the configuration information obtainable from a
+Allied device through SNMP. See inherited classes' documentation for
 inherited methods.
 
 =head2 Inherited Classes
@@ -181,7 +181,7 @@ Returns 'allied' :)
 
 =item $allied->os()
 
-Returns 'allied' 
+Returns 'allied'
 
 =item $allied->os_ver()
 

--- a/lib/SNMP/Info/Layer1/Asante.pm
+++ b/lib/SNMP/Info/Layer1/Asante.pm
@@ -173,14 +173,14 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $asante = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $asante->class();
@@ -188,7 +188,7 @@ Max Baker
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from a 
+Provides abstraction to the configuration information obtainable from a
 Asante device through SNMP.
 
 =head2 Inherited Classes
@@ -250,7 +250,7 @@ See L<SNMP::Info::Layer1/"GLOBALS"> for details.
 
 Returns reference to the map between IID and physical Port.
 
-=item $asante->i_description() 
+=item $asante->i_description()
 
 Description of the interface.
 

--- a/lib/SNMP/Info/Layer1/Bayhub.pm
+++ b/lib/SNMP/Info/Layer1/Bayhub.pm
@@ -492,7 +492,7 @@ Eric Miller
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
 
     or die "Can't connect to DestHost.\n";
 
@@ -501,12 +501,12 @@ Eric Miller
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from a 
+Provides abstraction to the configuration information obtainable from a
 Bay hub device through SNMP.  Also provides device MAC to port mapping through
-the proprietary MIB. 
+the proprietary MIB.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
 my $bayhub = new SNMP::Info::Layer1::Bayhub(...);
 
@@ -607,18 +607,18 @@ to a hash.
 
 =item $bayhub->i_index()
 
-Returns reference to map of IIDs to Interface index. 
+Returns reference to map of IIDs to Interface index.
 
 Since hubs do not support C<ifIndex>, the interface index is created using the
 formula (board * 256 + port).
 
 =item $bayhub->interfaces()
 
-Returns reference to map of IIDs to physical ports. 
+Returns reference to map of IIDs to physical ports.
 
 =item $bayhub->i_duplex()
 
-Returns half, hubs do not support full duplex. 
+Returns half, hubs do not support full duplex.
 
 =item $bayhub->i_duplex_admin()
 
@@ -644,7 +644,7 @@ State choices are 'up' or 'down'
 
 Example:
   my %if_map = reverse %{$bayhub->interfaces()};
-  $bayhub->set_i_up_admin('down', $if_map{'1.1'}) 
+  $bayhub->set_i_up_admin('down', $if_map{'1.1'})
       or die "Couldn't change port state. ",$bayhub->error(1);
 
 =item $bayhub->bp_index()
@@ -671,51 +671,51 @@ L<SNMP::Info::NortelStack/"TABLE METHODS"> for details.
 
 =over
 
-=item $bayhub->e_index() 
+=item $bayhub->e_index()
 
 Returns ns_e_index().
 
-=item $bayhub->e_class() 
+=item $bayhub->e_class()
 
 Returns ns_e_class().
 
-=item $bayhub->e_descr() 
+=item $bayhub->e_descr()
 
 Returns ns_e_descr().
 
-=item $bayhub->e_name() 
+=item $bayhub->e_name()
 
 Returns ns_e_name().
 
-=item $bayhub->e_fwver() 
+=item $bayhub->e_fwver()
 
 Returns ns_e_fwver().
 
-=item $bayhub->e_hwver() 
+=item $bayhub->e_hwver()
 
 Returns ns_e_hwver().
 
-=item $bayhub->e_parent() 
+=item $bayhub->e_parent()
 
 Returns ns_e_parent().
 
-=item $bayhub->e_pos() 
+=item $bayhub->e_pos()
 
 Returns ns_e_pos().
 
-=item $bayhub->e_serial() 
+=item $bayhub->e_serial()
 
 Returns ns_e_serial().
 
-=item $bayhub->e_swver() 
+=item $bayhub->e_swver()
 
 Returns ns_e_swver().
 
-=item $bayhub->e_type() 
+=item $bayhub->e_type()
 
 Returns ns_e_type().
 
-=item $bayhub->e_vendor() 
+=item $bayhub->e_vendor()
 
 Returns ns_e_vendor().
 

--- a/lib/SNMP/Info/Layer1/Cyclades.pm
+++ b/lib/SNMP/Info/Layer1/Cyclades.pm
@@ -486,7 +486,7 @@ Eric Miller
                         DestHost    => 'myswitch',
                         Community   => 'public',
                         Version     => 2
-                        ) 
+                        )
 
     or die "Can't connect to DestHost.\n";
 
@@ -495,11 +495,11 @@ Eric Miller
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from a 
+Provides abstraction to the configuration information obtainable from a
 Cyclades/Avocent device through SNMP.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
 my $cyclades = new SNMP::Info::Layer1::Cyclades(...);
 
@@ -602,12 +602,12 @@ to a hash.
 
 =item $cyclades->i_index()
 
-Returns reference to map of IIDs to Interface index. 
+Returns reference to map of IIDs to Interface index.
 
 Extended to include serial ports.  Serial ports are indexed with the
 alternative labeling system for the serial port, either the listening socket
 port C<cySPortSocketPort> or C<acsSerialPortTableDeviceName> name to avoid
-conflicts with C<ifIndex>.  
+conflicts with C<ifIndex>.
 
 =item $cyclades->interfaces()
 
@@ -617,7 +617,7 @@ serial ports, C<acsSerialPortTableDeviceName> or C<cyISPortTty>.
 =item $cyclades->i_speed()
 
 Returns interface speed.  Extended to include serial ports,
-C<acsSerialPortTableComSpeed> or C<cyISPortSpeed>. 
+C<acsSerialPortTableComSpeed> or C<cyISPortSpeed>.
 
 =item $cyclades->i_up()
 

--- a/lib/SNMP/Info/Layer1/S3000.pm
+++ b/lib/SNMP/Info/Layer1/S3000.pm
@@ -373,7 +373,7 @@ Eric Miller
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
 
     or die "Can't connect to DestHost.\n";
 
@@ -382,12 +382,12 @@ Eric Miller
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from a 
+Provides abstraction to the configuration information obtainable from a
 Bay hub device through SNMP.  Also provides device MAC to port mapping through
 the proprietary MIB.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
 my $s3000 = new SNMP::Info::Layer1::S3000(...);
 
@@ -447,7 +447,7 @@ Returns the firmware version. (C<s3AgentFwVer>)
 
 =item $s3000->mac()
 
-Returns MAC of the advertised IP address of the device. 
+Returns MAC of the advertised IP address of the device.
 
 =back
 
@@ -477,7 +477,7 @@ to a hash.
 
 =item $s3000->i_index()
 
-Returns reference to map of IIDs to Interface index. 
+Returns reference to map of IIDs to Interface index.
 
 Since hubs do not support C<ifIndex>, the interface index is created using the
 formula (board * 256 + port).  This is required to support devices with more
@@ -485,11 +485,11 @@ than one module.
 
 =item $s3000->interfaces()
 
-Returns reference to map of IIDs to physical ports. 
+Returns reference to map of IIDs to physical ports.
 
 =item $s3000->i_duplex()
 
-Returns half, hubs do not support full duplex. 
+Returns half, hubs do not support full duplex.
 
 =item $s3000->i_duplex_admin()
 
@@ -516,7 +516,7 @@ State choices are 'up' or 'down'
 
 Example:
   my %if_map = reverse %{$s3000->interfaces()};
-  $s3000->set_i_up_admin('down', $if_map{'1.1'}) 
+  $s3000->set_i_up_admin('down', $if_map{'1.1'})
       or die "Couldn't change port state. ",$s3000->error(1);
 
 =item $s3000->bp_index()

--- a/lib/SNMP/Info/Layer2.pm
+++ b/lib/SNMP/Info/Layer2.pm
@@ -169,14 +169,14 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $l2 = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $l2->class();
@@ -199,11 +199,11 @@ This class is usually used as a superclass for more specific device classes
 listed under SNMP::Info::Layer2::*   Please read all docs under SNMP::Info
 first.
 
-Provides abstraction to the configuration information obtainable from a 
+Provides abstraction to the configuration information obtainable from a
 Layer2 device through SNMP.  Information is stored in a number of MIBs.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $l2 = new SNMP::Info::Layer2(...);
 
@@ -243,7 +243,7 @@ These are methods that return scalar value from SNMP
 
 =item $l2->model()
 
-Cross references $l2->id() with product IDs in the 
+Cross references $l2->id() with product IDs in the
 Cisco MIBs.
 
 For HP devices, removes C<'hpswitch'> from the name

--- a/lib/SNMP/Info/Layer2/Adtran.pm
+++ b/lib/SNMP/Info/Layer2/Adtran.pm
@@ -45,7 +45,7 @@ $VERSION = '3.64';
 # table by the serial() function.
 our $index = undef;
 
-%MIBS = ( 
+%MIBS = (
     %SNMP::Info::Layer2::MIBS,
     %SNMP::Info::Layer3::MIBS,
 #    'ADTRAN-GENEVC-MIB'     => 'adGenEVCMIB',
@@ -53,11 +53,11 @@ our $index = undef;
 #    'ADTRAN-GENPORT-MIB'    => 'adGenPort',
     'ADTRAN-MIB'            => 'adtran',
     'ADTRAN-AOSUNIT'     => 'adGenAOSUnitMib',
- );
+);
 
 %GLOBALS = (
-    %SNMP::Info::Layer2::GLOBALS, 
-    %SNMP::Info::Layer3::GLOBALS, 
+    %SNMP::Info::Layer2::GLOBALS,
+    %SNMP::Info::Layer3::GLOBALS,
     %SNMP::Info::LLDP::GLOBALS,
     'serial'    => 'adProdSerialNumber',
     'ad_mgmtevcvid' => 'adGenEVCSysMgmtEVCSTagVID',
@@ -65,7 +65,7 @@ our $index = undef;
 
 %FUNCS = ( %SNMP::Info::Layer2::FUNCS,
            %SNMP::Info::Layer3::FUNCS,
-           %SNMP::Info::LLDP::FUNCS, 
+           %SNMP::Info::LLDP::FUNCS,
            'ad_evcstag' => 'adGenEVCLookupName',
            'ad_menport' => 'adGenMenPortRowStatus',
            'ad_evcnamevid' => 'adGenEVCSTagVID',
@@ -86,11 +86,11 @@ sub os {
 
 sub layers {
     my $adtran = shift;
-    
+
     my $layers = $adtran->SUPER::layers();
-    # Some netvantas don't report L2 properly 
+    # Some netvantas don't report L2 properly
     my $macs   = $adtran->fw_mac();
-    
+
     if (keys %$macs) {
         my $l = substr $layers, 6, 1, "1";
     }
@@ -105,7 +105,7 @@ sub os_ver {
     my $aos_ver = $adtran->adAOSDeviceVersion();
     return $aos_ver;
 }
-sub model { 
+sub model {
     my $adtran = shift;
     my $id = $adtran->id();
     my $mod = $adtran->adProdName() || undef;
@@ -113,7 +113,7 @@ sub model {
     my $model = $adtran->adAOSDeviceProductName() || undef;
     return $model;
 }
-sub serial { 
+sub serial {
     my $adtran = shift;
     my $e_serial = $adtran->e_serial() || {};
     my $serial2 = $e_serial->{1} || undef;
@@ -124,19 +124,19 @@ sub serial {
 sub i_name {
     my $adtran = shift;
     my $partial = shift;
-    my $i_name = $adtran->SUPER::i_alias() || undef; 
+    my $i_name = $adtran->SUPER::i_alias() || undef;
     return $i_name if (defined $i_name);
     $i_name = {};
     my $adname = $adtran->ad_genportcustuse() || undef;
-    if (defined $adname) {  
-        foreach my $port (keys %$adname) { 
+    if (defined $adname) {
+        foreach my $port (keys %$adname) {
             my @split = split(/\./,$port);
             $i_name->{@split[1]} = $adname->{$port};
         }
     }
     return $i_name;
 }
-sub i_vlan { 
+sub i_vlan {
     my $adtran = shift;
     my $partial = shift;
     my $uniports = $adtran->ad_evcmapuniport() || undef;
@@ -155,14 +155,14 @@ sub i_vlan {
         return $i_vlan;
     }
     return {};
-        
+
 }
-        
-sub i_vlan_membership {         
+
+sub i_vlan_membership {
     my $adtran  = shift;
     my $partial = shift;
     my $i_vlan = $adtran->ad_menport();
-    if (defined $i_vlan) { 
+    if (defined $i_vlan) {
         my $vlans = {};
         my $v_name = $adtran->v_name();
         foreach my $vid (keys %$v_name) {
@@ -202,14 +202,14 @@ SNMP::Info::Layer2::Adtran - SNMP Interface to Adtran Devices
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $adtran = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $adtran->class();

--- a/lib/SNMP/Info/Layer2/Aerohive.pm
+++ b/lib/SNMP/Info/Layer2/Aerohive.pm
@@ -132,7 +132,7 @@ sub mac {
         push( @macs, $macs->{$iid} );
       }
       @macs = sort(@macs);
-    } 
+    }
     return $macs[0];
 }
 
@@ -323,14 +323,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $aerohive = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $aerohive->class();
@@ -339,10 +339,10 @@ Eric Miller
 =head1 DESCRIPTION
 
 Provides abstraction to the configuration information obtainable from an
-Aerohive wireless Access Point through SNMP. 
+Aerohive wireless Access Point through SNMP.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $aerohive = new SNMP::Info::Layer2::Aerohive(...);
 

--- a/lib/SNMP/Info/Layer2/Airespace.pm
+++ b/lib/SNMP/Info/Layer2/Airespace.pm
@@ -166,11 +166,11 @@ sub cd11_mac {
 
 sub cd11_txrate {
     my $airespace = shift;
-    
+
     my $rates  = $airespace->client_txrate() || {};
     my $protos = $airespace->cd11_proto()    || {};
     my $bws    = $airespace->cd11n_ch_bw()   || {};
-    
+
     my $cd11_txrate = {};
     foreach my $idx ( keys %$rates ) {
 	my $rate = $rates->{$idx} || '0.0';
@@ -193,7 +193,7 @@ sub cd11_txrate {
 
 sub munge_cd11n_ch_bw {
     my $bw = shift;
-    
+
     if ( $bw =~ /forty/ ) {
 	return 40;
     }
@@ -202,7 +202,7 @@ sub munge_cd11n_ch_bw {
 
 sub munge_cd11_proto {
     my $bw = shift;
-    
+
     return 2 if ( $bw eq 'dot11n5' );
 
     return 1;
@@ -260,7 +260,7 @@ Eric Miller
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
 
     or die "Can't connect to DestHost.\n";
 
@@ -269,11 +269,11 @@ Eric Miller
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from 
+Provides abstraction to the configuration information obtainable from
 Cisco (Airespace) Wireless Controllers through SNMP.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
 my $airespace = new SNMP::Info::Layer2::Airespace(...);
 
@@ -346,7 +346,7 @@ See documentation in L<SNMP::Info::Bridge/"GLOBALS"> for details.
 These are methods that return tables of information in the form of a reference
 to a hash.
 
-=over 
+=over
 
 =item cd11_mac()
 
@@ -356,7 +356,7 @@ Returns client radio interface MAC addresses.
 
 Returns client transmission speed in Mbs.
 
-=back 
+=back
 
 =head2 Overrides
 

--- a/lib/SNMP/Info/Layer2/Aironet.pm
+++ b/lib/SNMP/Info/Layer2/Aironet.pm
@@ -443,7 +443,7 @@ sub i_ssidmac {
     my $partial    = shift;
     my $mbss_mac_addr = $aironet->mbss_mac_addr();
 
-    # Same logic as i_ssidbcast to return same indexes as i_ssidlist 
+    # Same logic as i_ssidbcast to return same indexes as i_ssidlist
     my $map = {};
     foreach my $key ( keys %$mbss_mac_addr ) {
         my ( $interface, @idx ) = split( /\./, $key );
@@ -484,14 +484,14 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $aironet = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $aironet->class();
@@ -517,7 +517,7 @@ This class is for devices running Cisco IOS software (newer)
 =back
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
 my $aironet = new SNMP::Info::Layer2::Aironet(...);
 
@@ -655,11 +655,11 @@ being broadcast.
 =item $aironet->i_ssidmac()
 
 With the same keys as i_ssidlist, returns the Basic service set
-identification (BSSID), MAC address, the AP is using for the SSID. 
+identification (BSSID), MAC address, the AP is using for the SSID.
 
 =item $aironet ps1_status()
 
-Returns the PoE injector status based on C<cpoePdSupportedPower> and 
+Returns the PoE injector status based on C<cpoePdSupportedPower> and
 C<cpoePdSupportedPowerMode>.
 
 =back

--- a/lib/SNMP/Info/Layer2/Allied.pm
+++ b/lib/SNMP/Info/Layer2/Allied.pm
@@ -138,14 +138,14 @@ Max Baker, Dmitry Sergienko <dmitry@trifle.net>
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $allied = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myhub',
                           Community   => 'public',
                           Version     => 1
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $allied->class();
@@ -153,8 +153,8 @@ Max Baker, Dmitry Sergienko <dmitry@trifle.net>
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from a 
-Allied device through SNMP. See inherited classes' documentation for 
+Provides abstraction to the configuration information obtainable from a
+Allied device through SNMP. See inherited classes' documentation for
 inherited methods.
 
 =head2 Inherited Classes
@@ -195,7 +195,7 @@ Returns 'allied' :)
 
 =item $allied->os()
 
-Returns 'allied' 
+Returns 'allied'
 
 =item $allied->os_ver()
 
@@ -213,7 +213,7 @@ Tries to cull out C<AT-nnnnX> out of the description field.
 
 =item $allied->mac()
 
-Returns device MAC. 
+Returns device MAC.
 
 =back
 

--- a/lib/SNMP/Info/Layer2/Atmedia.pm
+++ b/lib/SNMP/Info/Layer2/Atmedia.pm
@@ -92,14 +92,14 @@ Netdisco Developers
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $atmedia = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myhub',
                           Community   => 'public',
                           Version     => 1
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $atmedia->class();

--- a/lib/SNMP/Info/Layer2/Baystack.pm
+++ b/lib/SNMP/Info/Layer2/Baystack.pm
@@ -136,7 +136,7 @@ sub model {
     return '303' if ( defined $descr and $descr =~ /\D303\D/ );
     return '304' if ( defined $descr and $descr =~ /\D304\D/ );
     return 'BPS' if ( $model =~ /BPS2000/i );
-    
+
     # Pull sreg- from all
     $model =~ s/^sreg-//;
     # Strip ES/ERS/BayStack etc. from those families
@@ -341,7 +341,7 @@ sub peth_port_ifindex {
     return \%peth_port_ifindex;
 }
 
-# Currently only ERS 4800 v5.8+ support the rcBridgeSpbmMacTable 
+# Currently only ERS 4800 v5.8+ support the rcBridgeSpbmMacTable
 # which holds the FDB for a SPBM edge deployment.
 #
 # Q-BRIDGE still holds some entries when the rcBridgeSpbmMacTable is in use
@@ -353,7 +353,7 @@ sub fw_mac {
     my $qb = $rapidcity->SUPER::fw_mac() || {};
     my $spbm = $rapidcity->rc_spbm_fw_mac() || {};
     my $fw_mac = { %$qb, %$spbm };
-    
+
     return $fw_mac;
 }
 
@@ -363,17 +363,17 @@ sub fw_port {
     my $qb = $rapidcity->SUPER::fw_port() || {};
     my $spbm = $rapidcity->rc_spbm_fw_port() || {};
     my $fw_port = { %$qb, %$spbm };
-    
+
     return $fw_port;
 }
 
 sub fw_status {
     my $rapidcity = shift;
 
-    my $qb = $rapidcity->SUPER::fw_status() || {};    
+    my $qb = $rapidcity->SUPER::fw_status() || {};
     my $spbm = $rapidcity->rc_spbm_fw_status() || {};
     my $fw_status = { %$qb, %$spbm };
-    
+
     return $fw_status;
 }
 
@@ -383,7 +383,7 @@ sub qb_fw_vlan {
     my $qb = $rapidcity->SUPER::qb_fw_vlan() || {};
     my $spbm = $rapidcity->rc_spbm_fw_vlan() || {};
     my $qb_fw_vlan = { %$qb, %$spbm };
-    
+
     return $qb_fw_vlan;
 }
 
@@ -417,7 +417,7 @@ Eric Miller
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
   or die "Can't connect to DestHost.\n";
 
  my $class = $baystack->class();
@@ -427,10 +427,10 @@ Eric Miller
 
 Provides abstraction to the configuration information obtainable from an
 Avaya Ethernet Switch (formerly Nortel/Bay Baystack) and VSP 7000 series
-through SNMP. 
+through SNMP.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
 my $baystack = new SNMP::Info::Layer2::Baystack(...);
 
@@ -500,7 +500,7 @@ Returns the firmware version extracted from C<sysDescr>.
 
 =item $baystack->stp_ver()
 
-Returns the particular STP version running on this device.  
+Returns the particular STP version running on this device.
 
 Values: C<nortelStpg>, C<pvst>, C<rstp>, C<mstp>, C<ieee8021d>
 
@@ -560,10 +560,10 @@ Returns reference to the map between IID and physical Port.
 
   Slot and port numbers on the Baystack switches are determined by the
   formula:
-  
+
   port = (Interface index % Index factor)
   slot = (int(Interface index / Index factor)) + Slot offset
- 
+
   The physical port name is returned as slot.port.
 
 =item $baystack->i_ignore()
@@ -572,9 +572,9 @@ Returns reference to hash of IIDs to ignore.
 
 =item $baystack->i_mac()
 
-Returns the C<ifPhysAddress> table entries. 
+Returns the C<ifPhysAddress> table entries.
 
-Removes all entries matching '00:00:00:00:00:00' -- Certain 
+Removes all entries matching '00:00:00:00:00:00' -- Certain
 revisions of Baystack firmware report all zeros for each port mac.
 
 =item $baystack->i_name()
@@ -602,60 +602,60 @@ L<SNMP::Info::NortelStack/"TABLE METHODS"> for details on ns_e_* methods.
 
 =over
 
-=item $baystack->e_index() 
+=item $baystack->e_index()
 
 If the device doesn't support C<entPhysicalDescr>, this will try ns_e_index().
 Note that this is based on C<entPhysicalDescr> due to implementation
 details of SNMP::Info::Entity::e_index().
 
-=item $baystack->e_class() 
+=item $baystack->e_class()
 
 If the device doesn't support C<entPhysicalClass>, this will try ns_e_class().
 
-=item $baystack->e_descr() 
+=item $baystack->e_descr()
 
 If the device doesn't support C<entPhysicalDescr>, this will try ns_e_descr().
 
-=item $baystack->e_name() 
+=item $baystack->e_name()
 
 If the device doesn't support C<entPhysicalName>, this will try ns_e_name().
 
-=item $baystack->e_fwver() 
+=item $baystack->e_fwver()
 
 If the device doesn't support C<entPhysicalFirmwareRev>, this will try
 ns_e_fwver().
 
-=item $baystack->e_hwver() 
+=item $baystack->e_hwver()
 
 If the device doesn't support C<entPhysicalHardwareRev>, this will try
 ns_e_hwver().
 
-=item $baystack->e_parent() 
+=item $baystack->e_parent()
 
 If the device doesn't support C<entPhysicalContainedIn>, this will try
 ns_e_parent().
 
-=item $baystack->e_pos() 
+=item $baystack->e_pos()
 
 If the device doesn't support C<entPhysicalParentRelPos>, this will try
 ns_e_pos().
 
-=item $baystack->e_serial() 
+=item $baystack->e_serial()
 
 If the device doesn't support C<entPhysicalSerialNum>, this will try
 ns_e_serial().
 
-=item $baystack->e_swver() 
+=item $baystack->e_swver()
 
 If the device doesn't support C<entPhysicalSoftwareRev>, this will try
 ns_e_swver().
 
-=item $baystack->e_type() 
+=item $baystack->e_type()
 
 If the device doesn't support C<entPhysicalVendorType>, this will try
 ns_e_type().
 
-=item $baystack->e_vendor() 
+=item $baystack->e_vendor()
 
 If the device doesn't support C<entPhysicalMfgName>, this will try
 ns_e_vendor().

--- a/lib/SNMP/Info/Layer2/C1900.pm
+++ b/lib/SNMP/Info/Layer2/C1900.pm
@@ -291,14 +291,14 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $c1900 = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 1
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $c1900->class();
@@ -312,7 +312,7 @@ Catalyst 1900 device through SNMP.  See SNMP::Info for full documentation
 Note that most of these devices only talk SNMP version 1, but not all.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $c1900 = new SNMP::Info::Layer2::C1900(...);
 
@@ -379,8 +379,8 @@ Returns 'catalyst'
 
 =item $c1900->os_ver()
 
-Returns CatOS version if obtainable.  First tries to use 
-SNMP::Info::CiscoStats->os_ver() .  If that fails then it 
+Returns CatOS version if obtainable.  First tries to use
+SNMP::Info::CiscoStats->os_ver() .  If that fails then it
 checks for the presence of $c1900->c1900_flash_status() and culls
 the version from there.
 
@@ -467,7 +467,7 @@ bridge group IDs.
   Example:
   my $interfaces = $c1900->interfaces();
   my $vlans      = $c1900->i_vlan_membership();
-  
+
   foreach my $iid (sort keys %$interfaces) {
     my $port = $interfaces->{$iid};
     my $vlan = join(',', sort(@{$vlans->{$iid}}));
@@ -510,7 +510,7 @@ Gives admin setting for Duplex Info
 
 =item $c1900->c1900_p_name()
 
-Gives human set name for port 
+Gives human set name for port
 
 (C<swPortName>)
 
@@ -563,7 +563,7 @@ See L<SNMP::Info::Layer2/"TABLE METHODS"> for details.
 These are methods that provide SNMP set functionality for overridden methods
 or provide a simpler interface to complex set operations.  See
 L<SNMP::Info/"SETTING DATA VIA SNMP"> for general information on set
-operations. 
+operations.
 
 =over
 
@@ -574,7 +574,7 @@ choices are 'auto', 'half', 'full'.
 
   Example:
   my %if_map = reverse %{$c1900->interfaces()};
-  $c1900->set_i_duplex_admin('auto', $if_map{'1'}) 
+  $c1900->set_i_duplex_admin('auto', $if_map{'1'})
     or die "Couldn't change port duplex. ",$c1900->error(1);
 
 =back

--- a/lib/SNMP/Info/Layer2/C2900.pm
+++ b/lib/SNMP/Info/Layer2/C2900.pm
@@ -225,7 +225,7 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $c2900 = new SNMP::Info(
                         AutoSpecify => 1,
                         Debug       => 1,
@@ -233,7 +233,7 @@ Max Baker
                         DestHost    => 'myswitch',
                         Community   => 'public',
                         Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $c2900->class();
@@ -241,11 +241,11 @@ Max Baker
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from a 
-C2900 device through SNMP. 
+Provides abstraction to the configuration information obtainable from a
+C2900 device through SNMP.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $c2900 = new SNMP::Info::Layer2::C2900(...);
 
@@ -309,8 +309,8 @@ Returns reference to the map between IID and physical Port.
 On the 2900 devices i_name isn't reliable, so we override to just the
 description.
 
-Next all dots are changed for forward slashes so that the physical port name 
-is the same as the broad-casted CDP port name. 
+Next all dots are changed for forward slashes so that the physical port name
+is the same as the broad-casted CDP port name.
     (Ethernet0.1 -> Ethernet0/1)
 
 Also, any weird characters are removed, as I saw a few pop up.
@@ -333,7 +333,7 @@ Returns reference to hash of IIDs to admin speed setting.
 
 =back
 
-=head2 F<C2900-MIB> Port Entry Table 
+=head2 F<C2900-MIB> Port Entry Table
 
 =over
 
@@ -357,7 +357,7 @@ Gives admin setting for Duplex Info
 
 =item $c2900->c2900_p_speed_admin()
 
-Gives Admin speed of port 
+Gives Admin speed of port
 
 (C<c2900PortAdminSpeed>)
 
@@ -372,7 +372,7 @@ See L<SNMP::Info::Layer2::Cisco/"TABLE METHODS"> for details.
 These are methods that provide SNMP set functionality for overridden methods
 or provide a simpler interface to complex set operations.  See
 L<SNMP::Info/"SETTING DATA VIA SNMP"> for general information on set
-operations. 
+operations.
 
 =over
 
@@ -387,7 +387,7 @@ port C<ifIndex>.
 
     Example:
     my %if_map = reverse %{$c2900->interfaces()};
-    $c2900->set_i_speed_admin('auto', $if_map{'FastEthernet0/1'}) 
+    $c2900->set_i_speed_admin('auto', $if_map{'FastEthernet0/1'})
         or die "Couldn't change port speed. ",$c2900->error(1);
 
 =item $c2900->set_i_duplex_admin(duplex, ifIndex)
@@ -401,7 +401,7 @@ port C<ifIndex>.
 
     Example:
     my %if_map = reverse %{$c2900->interfaces()};
-    $c2900->set_i_duplex_admin('auto', $if_map{'FastEthernet0/1'}) 
+    $c2900->set_i_duplex_admin('auto', $if_map{'FastEthernet0/1'})
         or die "Couldn't change port duplex. ",$c2900->error(1);
 
 =back

--- a/lib/SNMP/Info/Layer2/Catalyst.pm
+++ b/lib/SNMP/Info/Layer2/Catalyst.pm
@@ -173,14 +173,14 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $cat = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $cat->class();
@@ -206,7 +206,7 @@ Note:  Some older Catalyst switches will only talk SNMP version 1.  Some
 newer ones will not return all their data if connected via Version 1.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $cat = new SNMP::Info::Layer2::Catalyst(...);
 
@@ -246,7 +246,7 @@ Returns 'catalyst'
 
 =item $cat->os_ver()
 
-Tries to use the value from SNMP::Info::CiscoStats->os_ver() and if it fails 
+Tries to use the value from SNMP::Info::CiscoStats->os_ver() and if it fails
 it grabs $cat->m_swver()->{1} and uses that.
 
 =item $cat->vendor()
@@ -279,11 +279,11 @@ to a hash.
 =item $cat->interfaces()
 
 Returns the map between SNMP Interface Identifier (iid) and physical port
-name. 
+name.
 
 =item $cat->i_name()
 
-Returns reference to hash of iid to human set name. 
+Returns reference to hash of iid to human set name.
 
 C<portName>
 

--- a/lib/SNMP/Info/Layer2/Centillion.pm
+++ b/lib/SNMP/Info/Layer2/Centillion.pm
@@ -274,14 +274,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $centillion = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $centillion->class();
@@ -289,14 +289,14 @@ Eric Miller
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from a 
-Centillion device through SNMP. 
+Provides abstraction to the configuration information obtainable from a
+Centillion device through SNMP.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $centillion = new SNMP::Info::Layer2::centillion(...);
- 
+
 Note:  This class supports version 4.X and 5.X which are VLAN based rather
 than bridge group based.
 
@@ -430,7 +430,7 @@ to a hash.
     formula:
       port = index % 256
       slot = int(index / 256)
- 
+
     The physical port name is returned as slot.port.
 
 =item $centillion->i_duplex()
@@ -469,13 +469,13 @@ Returns a mapping between C<ifIndex> and the VLAN.
 
 =item $centillion->centillion_p_index()
 
-Returns reference to hash.  Maps table IIDs to Interface IIDs 
+Returns reference to hash.  Maps table IIDs to Interface IIDs
 
 (C<cnDot3ExtnIfIndex>)
 
 =item $centillion->centillion_p_duplex()
 
-Returns reference to hash.  Maps port operational duplexes to IIDs 
+Returns reference to hash.  Maps port operational duplexes to IIDs
 
 (C<cnDot3ExtnIfOperConnectionType>)
 
@@ -493,19 +493,19 @@ Returns reference to hash.  Maps port admin duplexes to IIDs
 
 =item $centillion->centillion_i_vlan_index()
 
-Returns reference to hash.  Key: Table entry, Value: Index 
+Returns reference to hash.  Key: Table entry, Value: Index
 
 (C<cnVlanPortMemberIfIndex>)
 
 =item $centillion->centillion_i_vlan()
 
-Returns reference to hash.  Key: Table entry, Value: VLAN ID 
+Returns reference to hash.  Key: Table entry, Value: VLAN ID
 
 (C<cnVlanPortMemberVID>)
 
 =item $centillion->centillion_i_vlan_type()
 
-Returns reference to hash.  Key: Table entry, Value: VLAN Type 
+Returns reference to hash.  Key: Table entry, Value: VLAN Type
 
 (C<cnVlanPortMemberIngressType>)
 

--- a/lib/SNMP/Info/Layer2/Cisco.pm
+++ b/lib/SNMP/Info/Layer2/Cisco.pm
@@ -117,7 +117,7 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $cisco = new SNMP::Info(
                         AutoSpecify => 1,
                         Debug       => 1,
@@ -125,7 +125,7 @@ Max Baker
                         DestHost    => 'myswitch',
                         Community   => 'public',
                         Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $cisco->class();

--- a/lib/SNMP/Info/Layer2/Exinda.pm
+++ b/lib/SNMP/Info/Layer2/Exinda.pm
@@ -189,7 +189,7 @@ Returns 'exinda'.
 =back
 
 =head2 Global Methods imported from SNMP::Info::Layer2
- 
+
 See L<SNMP::Info::Layer2/"GLOBALS"> for details.
 
 =head1 TABLE ENTRIES
@@ -197,14 +197,8 @@ See L<SNMP::Info::Layer2/"GLOBALS"> for details.
 These are methods that return tables of information in the form of a reference
 to a hash.
 
-=head2 Overrides
-
-=over
-
-=back
-
 =head2 Table Methods imported from SNMP::Info::Layer2
- 
+
 See L<SNMP::Info::Layer2/"TABLE METHODS"> for details.
 
 =cut

--- a/lib/SNMP/Info/Layer2/HP.pm
+++ b/lib/SNMP/Info/Layer2/HP.pm
@@ -41,9 +41,9 @@ use SNMP::Info::Aggregate 'agg_ports_ifstack';
 
 @SNMP::Info::Layer2::HP::ISA = qw/
     SNMP::Info::Aggregate
-    SNMP::Info::Layer3 
-    SNMP::Info::MAU 
-    SNMP::Info::CDP 
+    SNMP::Info::Layer3
+    SNMP::Info::MAU
+    SNMP::Info::CDP
     Exporter
 /;
 @SNMP::Info::Layer2::HP::EXPORT_OK = qw//;
@@ -107,7 +107,7 @@ $VERSION = '3.64';
     'hp_s_oid'    => 'hpicfSensorObjectId',
     'hp_s_name'   => 'hpicfSensorDescr',
     'hp_s_status' => 'hpicfSensorStatus',
-    
+
     # HP-ICF-POE-MIB
     'peth_port_power'   => 'hpicfPoePethPsePortPower',
 );
@@ -123,7 +123,7 @@ $VERSION = '3.64';
 
 
 # Model map, reverse sorted by common model name (sort -k2 -r)
-# Potential sources for model information: http://www.hp.com/rnd/software/switches.htm or HP-ICF-OID MIB 
+# Potential sources for model information: http://www.hp.com/rnd/software/switches.htm or HP-ICF-OID MIB
 %MODEL_MAP = (
     'J8131A' => 'WAP-420-WW',
     'J8130A' => 'WAP-420-NA',
@@ -315,7 +315,7 @@ sub os_ver {
     return;
 }
 
-# Regular managed ProCurve switches have the serial num in entity mib, 
+# Regular managed ProCurve switches have the serial num in entity mib,
 # the web-managed models in the semi mib (hphttpmanageable).
 sub serial {
     my $hp = shift;
@@ -595,14 +595,14 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $hp = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $hp->class();
@@ -610,15 +610,15 @@ Max Baker
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from a 
-HP ProCurve Switch via SNMP. 
+Provides abstraction to the configuration information obtainable from a
+HP ProCurve Switch via SNMP.
 
 Note:  Some HP Switches will connect via SNMP version 1, but a lot of config
 data will not be available.  Make sure you try and connect with Version 2
 first, and then fail back to version 1.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $hp = new SNMP::Info::Layer2::HP(...);
 
@@ -874,7 +874,7 @@ to a hash.
 
 =over 4
 
-=item $hp->interfaces() 
+=item $hp->interfaces()
 
 Uses $hp->i_description()
 
@@ -931,7 +931,7 @@ Munge for c_id which handles CDP and LLDP.
 These are methods that provide SNMP set functionality for overridden methods
 or provide a simpler interface to complex set operations.  See
 L<SNMP::Info/"SETTING DATA VIA SNMP"> for general information on set
-operations. 
+operations.
 
 =over
 

--- a/lib/SNMP/Info/Layer2/HP4000.pm
+++ b/lib/SNMP/Info/Layer2/HP4000.pm
@@ -386,7 +386,7 @@ sub i_vlan_membership_untagged {
         my $vlan = $vlans->{$port};
         push( @{ $i_vlan_membership->{$port} }, $vlan );
     }
-    
+
     return $i_vlan_membership;
 }
 
@@ -482,14 +482,14 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $hp = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $hp->class();
@@ -497,15 +497,15 @@ Max Baker
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from a 
-HP ProCurve Switch via SNMP. 
+Provides abstraction to the configuration information obtainable from a
+HP ProCurve Switch via SNMP.
 
 Note:  Some HP Switches will connect via SNMP version 1, but a lot of config
 data will not be available.  Make sure you try and connect with Version 2
 first, and then fail back to version 1.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $hp = new SNMP::Info::Layer2::HP4000(...);
 
@@ -583,7 +583,7 @@ Returns bytes of used memory
 Returns the model number of the HP Switch.  Will translate between the HP Part
 number and the common model number with this map :
 
- %MODEL_MAP = ( 
+ %MODEL_MAP = (
                 'J4093A' => '2424M',
                 'J4110A' => '8000M',
                 'J4120A' => '1600M',
@@ -652,7 +652,7 @@ to a hash.
 
 =over
 
-=item $hp->interfaces() 
+=item $hp->interfaces()
 
 Uses $hp->i_description()
 
@@ -687,7 +687,7 @@ It is the union of tagged, untagged, and auto ports.
   Example:
   my $interfaces = $hp->interfaces();
   my $vlans      = $hp->i_vlan_membership();
-  
+
   foreach my $iid (sort keys %$interfaces) {
     my $port = $interfaces->{$iid};
     my $vlan = join(',', sort(@{$vlans->{$iid}}));
@@ -731,7 +731,7 @@ See documentation in L<SNMP::Info::MAU/"TABLE METHODS"> for details.
 These are methods that provide SNMP set functionality for overridden methods
 or provide a simpler interface to complex set operations.  See
 L<SNMP::Info/"SETTING DATA VIA SNMP"> for general information on set
-operations. 
+operations.
 
 =over
 

--- a/lib/SNMP/Info/Layer2/HPVC.pm
+++ b/lib/SNMP/Info/Layer2/HPVC.pm
@@ -188,21 +188,9 @@ See documentation in L<SNMP::Info::Layer2/"GLOBALS"> for details.
 These are methods that return tables of information in the form of a reference
 to a hash.
 
-=head2 Overrides
-
-=over
-
-=back
-
 =head2 Table Methods imported from SNMP::Info::Layer2
 
 See documentation in L<SNMP::Info::Layer2/"TABLE METHODS"> for details.
-
-=head1 MUNGES
-
-=over
-
-=back
 
 =head1 SET METHODS
 

--- a/lib/SNMP/Info/Layer2/HPVC.pm
+++ b/lib/SNMP/Info/Layer2/HPVC.pm
@@ -63,7 +63,7 @@ $VERSION = '3.64';
 %FUNCS = (
     %SNMP::Info::Layer2::FUNCS,
     %SNMP::Info::LLDP::FUNCS,
-    
+
 );
 
 %MUNGE = (
@@ -102,14 +102,14 @@ Jeroen van Ingen
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $hp = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $hp->class();
@@ -117,11 +117,11 @@ Jeroen van Ingen
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from a 
-HP Virtual Connect Switch via SNMP. 
+Provides abstraction to the configuration information obtainable from a
+HP Virtual Connect Switch via SNMP.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $hp = new SNMP::Info::Layer2::HPVC(...);
 
@@ -209,6 +209,6 @@ See documentation in L<SNMP::Info::Layer2/"TABLE METHODS"> for details.
 These are methods that provide SNMP set functionality for overridden methods
 or provide a simpler interface to complex set operations.  See
 L<SNMP::Info/"SETTING DATA VIA SNMP"> for general information on set
-operations. 
+operations.
 
 =cut

--- a/lib/SNMP/Info/Layer2/Kentrox.pm
+++ b/lib/SNMP/Info/Layer2/Kentrox.pm
@@ -168,12 +168,6 @@ See documentation in L<SNMP::Info::Layer2/"GLOBALS"> for details.
 These are methods that return tables of information in the form of a reference
 to a hash.
 
-=head2 Overrides
-
-=over
-
-=back
-
 =head2 Table Methods imported from SNMP::Info::Layer2
 
 See documentation in L<SNMP::Info::Layer2/"TABLE METHODS"> for details.

--- a/lib/SNMP/Info/Layer2/N2270.pm
+++ b/lib/SNMP/Info/Layer2/N2270.pm
@@ -114,7 +114,7 @@ Eric Miller
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
 
     or die "Can't connect to DestHost.\n";
 
@@ -123,11 +123,11 @@ Eric Miller
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from a 
+Provides abstraction to the configuration information obtainable from a
 Nortel 2270 Series Wireless Switch through SNMP.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
 my $n2270 = new SNMP::Info::Layer2::N2270(...);
 

--- a/lib/SNMP/Info/Layer2/NAP222x.pm
+++ b/lib/SNMP/Info/Layer2/NAP222x.pm
@@ -375,14 +375,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $nap222x = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $nap222x->class();
@@ -391,10 +391,10 @@ Eric Miller
 =head1 DESCRIPTION
 
 Provides abstraction to the configuration information obtainable from a Nortel
-2220 series wireless Access Points through SNMP. 
+2220 series wireless Access Points through SNMP.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $nap222x = new SNMP::Info::Layer2::NAP222x(...);
 
@@ -526,7 +526,7 @@ to a hash.
 
 =item $nap222x->interfaces()
 
-Returns reference to map of IIDs to physical ports. 
+Returns reference to map of IIDs to physical ports.
 
 =item $nap222x->i_duplex()
 
@@ -548,7 +548,7 @@ Returns a human name based upon port description.
 
 Returns a mapping between C<ifIndex> and the Bridge Table.  This does not
 exist in the MIB and bridge port index is not the same as C<ifIndex> so it is
-created. 
+created.
 
 =item $nap222x->i_ssidlist()
 

--- a/lib/SNMP/Info/Layer2/NWSS2300.pm
+++ b/lib/SNMP/Info/Layer2/NWSS2300.pm
@@ -159,7 +159,7 @@ sub model {
     return $id unless defined $model;
 
     $model =~ s/^ntwsSwitch//i;
-    return $model;    
+    return $model;
 }
 
 sub _ap_serial {
@@ -389,7 +389,7 @@ sub bp_index {
 sub fw_mac {
     my $nwss2300 = shift;
     my $partial  = shift;
-    
+
     my $serials = $nwss2300->nwss2300_sta_serial($partial) || {};
 
     my %fw_mac;
@@ -401,7 +401,7 @@ sub fw_mac {
 	
         $fw_mac{$iid} = $mac;
     }
-    return \%fw_mac;    
+    return \%fw_mac;
 }
 
 sub fw_port {
@@ -494,7 +494,7 @@ sub dot11_cur_tx_pwr_mw {
     my $partial  = shift;
 
     my $cur = $nwss2300->nwss2300_apif_power($partial);
-    
+
     my $dot11_cur_tx_pwr_mw = {};
     foreach my $idx ( keys %$cur ) {
         my $pwr_dbm = $cur->{$idx};
@@ -502,7 +502,7 @@ sub dot11_cur_tx_pwr_mw {
 	#Convert to milliWatts = 10(dBm/10)
         my $pwr = int (10 ** ($pwr_dbm / 10));
 	
-        $dot11_cur_tx_pwr_mw->{$idx} = $pwr; 
+        $dot11_cur_tx_pwr_mw->{$idx} = $pwr;
     }
     return $dot11_cur_tx_pwr_mw;
 }
@@ -514,7 +514,7 @@ sub e_index {
 
     # Try new first, fall back to depreciated
     my $ap_num = $nwss2300->nwss2300_ap_num() || $nwss2300->nwss2300_ap_dapnum() || {};
-  
+
     my %e_index;
 
     # Chassis
@@ -797,7 +797,7 @@ Eric Miller
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
 
     or die "Can't connect to DestHost.\n";
 
@@ -806,7 +806,7 @@ Eric Miller
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from 
+Provides abstraction to the configuration information obtainable from
 Avaya (Trapeze) Wireless Controllers through SNMP.
 
 This class emulates bridge functionality for the wireless switch. This enables
@@ -814,7 +814,7 @@ end station MAC addresses collection and correlation to the thin access point
 the end station is using for communication.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
 my $nwss2300 = new SNMP::Info::Layer2::NWSS2300(...);
 
@@ -908,7 +908,7 @@ See documentation in L<SNMP::Info::Bridge/"GLOBALS"> for details.
 These are methods that return tables of information in the form of a reference
 to a hash.
 
-=over 
+=over
 
 =item $nwss2300->i_ssidlist()
 
@@ -1139,7 +1139,7 @@ These emulate the F<CISCO-DOT11-MIB>
 
 (C<ntwsClSessClientSessStatsUniPktOut>)
 
-=back 
+=back
 
 =head2 Table Methods imported from SNMP::Info
 
@@ -1155,14 +1155,14 @@ See documentation in L<SNMP::Info::Bridge/"TABLE METHODS"> for details.
 
 =item $nwss2300->i_index()
 
-Returns reference to map of IIDs to Interface index. 
+Returns reference to map of IIDs to Interface index.
 
 Extends C<ifIndex> to support thin APs and WLAN virtual interfaces as device
 interfaces.
 
 =item $nwss2300->interfaces()
 
-Returns reference to map of IIDs to ports.  Thin APs are implemented as device 
+Returns reference to map of IIDs to ports.  Thin APs are implemented as device
 interfaces.  The thin AP MAC address and Slot ID nwss2300_apif_slot() are
 used as the port identifier.
 
@@ -1207,7 +1207,7 @@ the interface iid.
 =item $nwss2300->fw_port()
 
 Returns reference to a hash, value being mac and
-nwss2300_sta_slot() combined to match the interface iid.  
+nwss2300_sta_slot() combined to match the interface iid.
 
 =item $nwss2300->fw_mac()
 

--- a/lib/SNMP/Info/Layer2/Netgear.pm
+++ b/lib/SNMP/Info/Layer2/Netgear.pm
@@ -74,7 +74,7 @@ sub os {
 sub serial {
     my $netgear = shift;
     my $serial = undef;
-    
+
     my $e_serial = $netgear->e_serial();
     if (defined($e_serial)) { # This unit sports the Entity-MIB
         # Find entity table entry for this unit
@@ -108,7 +108,7 @@ sub model {
 }
 
 # ifDescr is the same for all interfaces in a class, but the ifName is
-# unique, so let's use that for port name.  If all else fails, 
+# unique, so let's use that for port name.  If all else fails,
 # concatentate ifDesc and ifIndex.
 sub interfaces {
     my $netgear = shift;
@@ -162,20 +162,20 @@ SNMP::Info::Layer2::Netgear - SNMP Interface to Netgear switches
 
 =head1 AUTHOR
 
- Bill Fenner and Zoltan Erszenyi, 
- Hacked in LLDP support from Baystack.pm by 
+ Bill Fenner and Zoltan Erszenyi,
+ Hacked in LLDP support from Baystack.pm by
  Nic Bernstein <nic@onlight.com>
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $netgear = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $netgear->class();
@@ -183,8 +183,8 @@ SNMP::Info::Layer2::Netgear - SNMP Interface to Netgear switches
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from a 
-Netgear device through SNMP. See inherited classes' documentation for 
+Provides abstraction to the configuration information obtainable from a
+Netgear device through SNMP. See inherited classes' documentation for
 inherited methods.
 
 =head2 Inherited Classes
@@ -226,11 +226,11 @@ Returns 'netgear'
 
 =item $netgear->os()
 
-Returns 'netgear' 
+Returns 'netgear'
 
 =item $netgear->model()
 
-Returns concatenation of $e_model and $e_hwver if Entity MIB present, 
+Returns concatenation of $e_model and $e_hwver if Entity MIB present,
 otherwise returns description()
 
 =item $netgear->os_ver()

--- a/lib/SNMP/Info/Layer2/Nexans.pm
+++ b/lib/SNMP/Info/Layer2/Nexans.pm
@@ -114,7 +114,7 @@ sub i_name {
     # replace i_name where possible
     foreach my $iid ( keys %$return ) {
         next unless $return->{$iid} eq "";
-        $return->{$iid} = $iid; 
+        $return->{$iid} = $iid;
     }
     return \%$return;
 }
@@ -133,7 +133,7 @@ Christoph Neuhaus
 
 =head1 SYNOPSIS
 
-# Let SNMP::Info determine the correct subclass for you. 
+# Let SNMP::Info determine the correct subclass for you.
 
     my $nexans = new SNMP::Info(
                             AutoSpecify => 1,
@@ -141,7 +141,7 @@ Christoph Neuhaus
                             DestHost    => 'myswitch',
                             Community   => 'public',
                             Version     => 2
-                            ) 
+                            )
     or die "Can't connect to DestHost.\n";
 
     my $class = $nexans->class();
@@ -158,7 +158,7 @@ tested devices:
     gigaSwitchV3d2SfpSfp version 3.68, 4.02, 4.02B, 4.10C, 4,14W
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
     my $nexans = new SNMP::Info::Layer2::Nexans(...);
 
@@ -223,7 +223,7 @@ See documentation in L<SNMP::Info::Layer2/"GLOBALS"> for details.
 These are methods that return tables of information in the form of a reference
 to a hash.
 
-=over 
+=over
 
 =item $nexans->i_name()
 

--- a/lib/SNMP/Info/Layer2/Orinoco.pm
+++ b/lib/SNMP/Info/Layer2/Orinoco.pm
@@ -170,14 +170,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $orinoco = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $orinoco->class();
@@ -190,7 +190,7 @@ Orinoco Access Point through SNMP.  Orinoco devices have been manufactured
 by Proxim, Agere, and Lucent.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $orinoco = new SNMP::Info::Layer2::Orinoco(...);
 
@@ -269,7 +269,7 @@ to a hash.
 
 =item $orinoco->interfaces()
 
-Returns reference to map of IIDs to physical ports. 
+Returns reference to map of IIDs to physical ports.
 
 =item $orinoco->i_ignore()
 

--- a/lib/SNMP/Info/Layer2/Sixnet.pm
+++ b/lib/SNMP/Info/Layer2/Sixnet.pm
@@ -96,7 +96,7 @@ Eric Miller
               DestHost    => 'myswitch',
               Community   => 'public',
               Version     => 2
-            ) 
+            )
 
     or die "Can't connect to DestHost.\n";
 
@@ -109,7 +109,7 @@ SNMP::Info::Layer2::Sixnet is a subclass of SNMP::Info that provides an
 interface to Sixnet industrial switches.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $sixnet = new SNMP::Info::Layer2::Sixnet(...);
 

--- a/lib/SNMP/Info/Layer2/Trapeze.pm
+++ b/lib/SNMP/Info/Layer2/Trapeze.pm
@@ -163,7 +163,7 @@ sub model {
     return $id unless defined $model;
 
     $model =~ s/^wirelessLANController//i;
-    return $model;    
+    return $model;
 }
 
 sub _ap_serial {
@@ -393,7 +393,7 @@ sub bp_index {
 sub fw_mac {
     my $trapeze = shift;
     my $partial  = shift;
-    
+
     my $serials = $trapeze->trapeze_sta_serial($partial) || {};
 
     my %fw_mac;
@@ -405,7 +405,7 @@ sub fw_mac {
 	
         $fw_mac{$iid} = $mac;
     }
-    return \%fw_mac;    
+    return \%fw_mac;
 }
 
 sub fw_port {
@@ -498,7 +498,7 @@ sub dot11_cur_tx_pwr_mw {
     my $partial  = shift;
 
     my $cur = $trapeze->trapeze_apif_power($partial);
-    
+
     my $dot11_cur_tx_pwr_mw = {};
     foreach my $idx ( keys %$cur ) {
         my $pwr_dbm = $cur->{$idx};
@@ -506,7 +506,7 @@ sub dot11_cur_tx_pwr_mw {
 	#Convert to milliWatts = 10(dBm/10)
         my $pwr = int (10 ** ($pwr_dbm / 10));
 	
-        $dot11_cur_tx_pwr_mw->{$idx} = $pwr; 
+        $dot11_cur_tx_pwr_mw->{$idx} = $pwr;
     }
     return $dot11_cur_tx_pwr_mw;
 }
@@ -518,7 +518,7 @@ sub e_index {
 
     # Try new first, fall back to depreciated
     my $ap_num = $trapeze->trapeze_ap_num() || $trapeze->trapeze_ap_dapnum() || {};
-  
+
     my %e_index;
 
     # Chassis
@@ -801,7 +801,7 @@ Eric Miller
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
 
     or die "Can't connect to DestHost.\n";
 
@@ -810,7 +810,7 @@ Eric Miller
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from 
+Provides abstraction to the configuration information obtainable from
 Juniper (Trapeze) Wireless Controllers through SNMP.
 
 This class emulates bridge functionality for the wireless switch. This enables
@@ -818,7 +818,7 @@ end station MAC addresses collection and correlation to the thin access point
 the end station is using for communication.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
 my $trapeze = new SNMP::Info::Layer2::Trapeze(...);
 
@@ -912,7 +912,7 @@ See documentation in L<SNMP::Info::Bridge/"GLOBALS"> for details.
 These are methods that return tables of information in the form of a reference
 to a hash.
 
-=over 
+=over
 
 =item $trapeze->i_ssidlist()
 
@@ -1143,7 +1143,7 @@ These emulate the F<CISCO-DOT11-MIB>
 
 (C<trpzClSessClientSessStatsUniPktOut>)
 
-=back 
+=back
 
 =head2 Table Methods imported from SNMP::Info
 
@@ -1159,14 +1159,14 @@ See documentation in L<SNMP::Info::Bridge/"TABLE METHODS"> for details.
 
 =item $trapeze->i_index()
 
-Returns reference to map of IIDs to Interface index. 
+Returns reference to map of IIDs to Interface index.
 
 Extends C<ifIndex> to support thin APs and WLAN virtual interfaces as device
 interfaces.
 
 =item $trapeze->interfaces()
 
-Returns reference to map of IIDs to ports.  Thin APs are implemented as device 
+Returns reference to map of IIDs to ports.  Thin APs are implemented as device
 interfaces.  The thin AP MAC address and Slot ID trapeze_apif_slot() are
 used as the port identifier.
 
@@ -1211,7 +1211,7 @@ the interface iid.
 =item $trapeze->fw_port()
 
 Returns reference to a hash, value being mac and
-trapeze_sta_slot() combined to match the interface iid.  
+trapeze_sta_slot() combined to match the interface iid.
 
 =item $trapeze->fw_mac()
 

--- a/lib/SNMP/Info/Layer2/Ubiquiti.pm
+++ b/lib/SNMP/Info/Layer2/Ubiquiti.pm
@@ -130,11 +130,11 @@ sub model {
         next unless defined $prod;
         return $prod;
     }
-    
+
     my $desc = $ubnt->description() || '';
-    
+
     ## Pull Model from beginning of description, separated by comma (EdgeSwitch)
-    if((lc $desc) =~ /^edgeswitch/){    
+    if((lc $desc) =~ /^edgeswitch/){
         my @mydesc = split(/, /, $desc);
         return $mydesc[0];
     }
@@ -151,15 +151,15 @@ sub model {
         my $ethCount = 0;
         my $switchCount = 0;
         #my $sfpCount = 0;
-        #my $poeCount = 0;  
-        my $memTotalReal = $ubnt->memTotalReal;   
+        #my $poeCount = 0;
+        my $memTotalReal = $ubnt->memTotalReal;
         my $cpuLoad = $ubnt->hrProcessorLoad;
         my $cpuCount = 0;
         ## My perl is lacking. Not sure if there's a more efficient way to find the cpu count
         foreach my $iid ( keys %$cpuLoad ) {
             $cpuCount++;
         }
-        
+
         my $ifDescs = $ubnt->ifDescr;
         foreach my $iid ( keys %$ifDescs ) {
             my $ifDesc = $ifDescs->{$iid};
@@ -172,7 +172,7 @@ sub model {
             }
         }
 
-        ## If people have other models to further fine-tune this logic that would be great. 
+        ## If people have other models to further fine-tune this logic that would be great.
         if($ethCount eq 9){
             ## Should be ER Infinity
             return "EdgeRouter Infinity"
@@ -190,7 +190,7 @@ sub model {
             ## failback string
             return "EdgeRouter eth-$ethCount switch-$switchCount mem-$memTotalReal cpuNum-$cpuCount";
         }
-        
+
     }
 }
 
@@ -221,14 +221,12 @@ sub mac {
 
             # syntax stolen from sub munge_mac in SNMP::Info
             $mac = lc join( ':', map { sprintf "%02x", $_ } unpack( 'C*', $mac ) );
-            return $mac if $mac =~ /^([0-9A-F][0-9A-F]:){5}[0-9A-F][0-9A-F]$/i;  
-            
+            return $mac if $mac =~ /^([0-9A-F][0-9A-F]:){5}[0-9A-F][0-9A-F]$/i;
         }
     }
-    
+
     # MAC malformed or missing
     return;
-
 }
 
 sub interfaces {
@@ -288,14 +286,14 @@ Max Kosmach
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $ubnt = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $ubnt->class();
@@ -307,7 +305,7 @@ Provides abstraction to the configuration information obtainable from
 Ubiquiti Access Point through SNMP.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $ubnt = new SNMP::Info::Layer2::Ubiquiti(...);
 

--- a/lib/SNMP/Info/Layer2/ZyXEL_DSLAM.pm
+++ b/lib/SNMP/Info/Layer2/ZyXEL_DSLAM.pm
@@ -103,7 +103,7 @@ sub ip {
     my $found_ip;
 
     # Since hashes are random add sort so we get the same address each time
-    # if there happens to be more than one. Will return highest numbered address 
+    # if there happens to be more than one. Will return highest numbered address
     foreach my $ip ( sort keys %{$ip_hash} ) {
         $found_ip = $ip
             if ( defined $ip
@@ -124,14 +124,14 @@ Dmitry Sergienko (C<dmitry@trifle.net>)
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $zyxel = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myhub',
                           Community   => 'public',
                           Version     => 1
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $l2->class();
@@ -139,8 +139,8 @@ Dmitry Sergienko (C<dmitry@trifle.net>)
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from a 
-ZyXEL device through SNMP. See inherited classes' documentation for 
+Provides abstraction to the configuration information obtainable from a
+ZyXEL device through SNMP. See inherited classes' documentation for
 inherited methods.
 
 =head2 Inherited Classes
@@ -178,7 +178,7 @@ Returns 'ZyXEL' :)
 
 =item $zyxel->os()
 
-Returns 'ZyXEL' 
+Returns 'ZyXEL'
 
 =item $zyxel->os_ver()
 

--- a/lib/SNMP/Info/Layer3.pm
+++ b/lib/SNMP/Info/Layer3.pm
@@ -351,14 +351,14 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $l3 = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $l3->class();
@@ -381,11 +381,11 @@ This class is usually used as a superclass for more specific device classes
 listed under SNMP::Info::Layer3::*   Please read all docs under SNMP::Info
 first.
 
-Provides generic methods for accessing SNMP data for Layer 3 network devices. 
-Includes support for Layer2+3 devices. 
+Provides generic methods for accessing SNMP data for Layer 3 network devices.
+Includes support for Layer2+3 devices.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $l3 = new SNMP::Info::Layer3(...);
 
@@ -461,7 +461,7 @@ Returns the BGP identifier of the local system
 
 =item $l3->bgp_local_as()
 
-Returns the local autonomous system number 
+Returns the local autonomous system number
 
 (C<bgpLocalAs.0>)
 
@@ -533,13 +533,13 @@ to a hash.
 =item $l3->interfaces()
 
 Returns the map between SNMP Interface Identifier (iid) and physical port
-name. 
+name.
 
 Only returns those iids that have a description listed in $l3->i_description()
 
 =item $l3->i_name()
 
-Returns reference to hash of iid to human set name. 
+Returns reference to hash of iid to human set name.
 
 Defaults to C<ifName>, but checks for an C<ifAlias>
 
@@ -547,8 +547,8 @@ Defaults to C<ifName>, but checks for an C<ifAlias>
 
 Returns reference to hash of iid to current link duplex setting.
 
-Maps $l3->el_index() to $l3->el_duplex, then culls out 
-full,half, or auto and sets the map to that value. 
+Maps $l3->el_index() to $l3->el_duplex, then culls out
+full,half, or auto and sets the map to that value.
 
 See L<SNMP::Info::Etherlike> for the el_index() and el_duplex() methods.
 
@@ -560,7 +560,7 @@ See L<SNMP::Info::Etherlike> for the el_index() and el_duplex() methods.
 
 =item $l3->at_index()
 
-Returns reference to hash.  Maps ARP table entries to Interface IIDs 
+Returns reference to hash.  Maps ARP table entries to Interface IIDs
 
 (C<ipNetToMediaIfIndex>)
 
@@ -569,7 +569,7 @@ the deprecated C<atIfIndex>.
 
 =item $l3->at_paddr()
 
-Returns reference to hash.  Maps ARP table entries to MAC addresses. 
+Returns reference to hash.  Maps ARP table entries to MAC addresses.
 
 (C<ipNetToMediaPhysAddress>)
 
@@ -578,7 +578,7 @@ the deprecated C<atPhysAddress>.
 
 =item $l3->at_netaddr()
 
-Returns reference to hash.  Maps ARP table entries to IP addresses. 
+Returns reference to hash.  Maps ARP table entries to IP addresses.
 
 (C<ipNetToMediaNetAddress>)
 

--- a/lib/SNMP/Info/Layer3/Aironet.pm
+++ b/lib/SNMP/Info/Layer3/Aironet.pm
@@ -224,14 +224,14 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $aironet = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $aironet->class();
@@ -257,7 +257,7 @@ This class is for devices running Cisco IOS software (newer)
 =back
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $aironet = new SNMP::Info::Layer3::Aironet(...);
 
@@ -280,7 +280,7 @@ after determining a more specific class using the method above.
 =back
 
 These MIBs are now included in the v2.tar.gz archive available from
-ftp.cisco.com.  Make sure you have a current version. 
+ftp.cisco.com.  Make sure you have a current version.
 
 =head1 GLOBALS
 
@@ -296,7 +296,7 @@ C<awcEtherDuplex.0>
 
 =item $aironet->mac()
 
-Gives the MAC Address of the wireless side 
+Gives the MAC Address of the wireless side
 
 C<dot11StationID.2>
 

--- a/lib/SNMP/Info/Layer3/AlcatelLucent.pm
+++ b/lib/SNMP/Info/Layer3/AlcatelLucent.pm
@@ -306,7 +306,7 @@ Bill Fenner
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $alu = new SNMP::Info(
                         AutoSpecify => 1,
                         Debug       => 1,
@@ -314,7 +314,7 @@ Bill Fenner
                         DestHost    => 'myswitch',
                         Community   => 'public',
                         Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $alu->class();

--- a/lib/SNMP/Info/Layer3/AlteonAD.pm
+++ b/lib/SNMP/Info/Layer3/AlteonAD.pm
@@ -163,14 +163,14 @@ sub ps1_status {
     my $alteon = shift;
     my $old_ps = $alteon->old_ps1_stat();
     my $new_ps = $alteon->new_ps_stat();
-    
+
     return $old_ps if $old_ps;
-    
+
     if ($new_ps) {
         return 'ok' if ($new_ps eq 'singlePowerSupplyOk');
         return 'failed' if ($new_ps eq 'firstPowerSupplyFailed');
     }
-    
+
     return;
 }
 
@@ -178,9 +178,9 @@ sub ps2_status {
     my $alteon = shift;
     my $old_ps = $alteon->old_ps2_stat();
     my $new_ps = $alteon->new_ps_stat();
-    
+
     return $old_ps if $old_ps;
-    
+
     if ($new_ps) {
         return 'ok' if ($new_ps eq 'doublePowerSupplyOk');
         return 'failed' if ($new_ps eq 'secondPowerSupplyFailed');
@@ -242,19 +242,19 @@ sub i_duplex {
 sub i_duplex_admin {
     my $alteon = shift;
 
-    my $ag_pref 
+    my $ag_pref
         = $alteon->new_ag_p_cfg_pref()
         || $alteon->old_ag_p_cfg_pref()
         || {};
-    my $ag_fe_auto 
+    my $ag_fe_auto
         = $alteon->new_ag_p_cfg_fe_auto()
         || $alteon->old_ag_p_cfg_fe_auto()
         || {};
-    my $ag_fe_mode 
+    my $ag_fe_mode
         = $alteon->new_ag_p_cfg_fe_mode()
         || $alteon->old_ag_p_cfg_fe_mode()
         || {};
-    my $ag_ge_auto 
+    my $ag_ge_auto
         = $alteon->new_ag_p_cfg_ge_auto()
         || $alteon->old_ag_p_cfg_ge_auto()
         || {};
@@ -395,7 +395,7 @@ sub i_vlan_membership_untagged {
         my $vlan = $vlans->{$port};
         push( @{ $i_vlan_membership->{$port} }, $vlan );
     }
-    
+
     return $i_vlan_membership;
 }
 
@@ -432,14 +432,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $alteon = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $alteon->class();
@@ -451,7 +451,7 @@ Abstraction subclass for Radware Alteon Series ADC switches and
 Nortel BladeCenter Layer2-3 GbE Switch Modules.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $alteon = new SNMP::Info::Layer3::AlteonAD(...);
 
@@ -581,7 +581,7 @@ IDs.  These are the VLANs which are members of the egress list for the port.
   Example:
   my $interfaces = $alteon->interfaces();
   my $vlans      = $alteon->i_vlan_membership();
-  
+
   foreach my $iid (sort keys %$interfaces) {
     my $port = $interfaces->{$iid};
     my $vlan = join(',', sort(@{$vlans->{$iid}}));

--- a/lib/SNMP/Info/Layer3/Altiga.pm
+++ b/lib/SNMP/Info/Layer3/Altiga.pm
@@ -4,20 +4,20 @@
 # Copyright (c) 2008 Jeroen van Ingen Schenau
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, with or without 
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 #     * Redistributions of source code must retain the above copyright notice,
 #       this list of conditions and the following disclaimer.
 #     * Redistributions in binary form must reproduce the above copyright
 #       notice, this list of conditions and the following disclaimer in the
 #       documentation and/or other materials provided with the distribution.
-#     * Neither the name of the University of California, Santa Cruz nor the 
-#       names of its contributors may be used to endorse or promote products 
+#     * Neither the name of the University of California, Santa Cruz nor the
+#       names of its contributors may be used to endorse or promote products
 #       derived from this software without specific prior written permission.
-# 
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE  
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
 # LIABLE FOR # ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
@@ -37,7 +37,7 @@ use SNMP::Info::Layer3;
 @SNMP::Info::Layer3::Altiga::ISA = qw/SNMP::Info::Layer3 Exporter/;
 @SNMP::Info::Layer3::Altiga::EXPORT_OK = qw//;
 
-use vars qw/$VERSION %GLOBALS %MIBS %FUNCS %MUNGE 
+use vars qw/$VERSION %GLOBALS %MIBS %FUNCS %MUNGE
             $int_include_vpn $fake_idx $type_class/;
 
 $VERSION = '3.64';
@@ -46,7 +46,7 @@ $VERSION = '3.64';
             %SNMP::Info::Layer3::MIBS,
             'ALTIGA-VERSION-STATS-MIB'  => 'alVersionString',
             'ALTIGA-SESSION-STATS-MIB'  => 'alActiveSessionCount',
-            'ALTIGA-HARDWARE-STATS-MIB' => 'alHardwarePs1Type',  
+            'ALTIGA-HARDWARE-STATS-MIB' => 'alHardwarePs1Type',
     );
 
 %GLOBALS = (
@@ -70,7 +70,7 @@ $VERSION = '3.64';
             'fan1_alarm'      => 'alHardwareFan1RpmAlarm',
             'fan2_alarm'      => 'alHardwareFan2RpmAlarm',
             'fan3_alarm'      => 'alHardwareFan3RpmAlarm',
-            
+
        );
 
 %FUNCS = (
@@ -189,7 +189,7 @@ sub interfaces {
     if ($int_include_vpn) {
         my $tun_type = $altiga->vpn_sess_protocol();
         my $peer = $altiga->vpn_sess_peer_ip();
-        my $remote = $altiga->vpn_sess_rem_ip(); 
+        my $remote = $altiga->vpn_sess_rem_ip();
         my $group = $altiga->vpn_sess_gid();
         foreach my $tunnel (keys %$tun_type) {
             if ($type_class->{$tun_type->{$tunnel}} eq 1) {
@@ -197,7 +197,7 @@ sub interfaces {
             }
         }
     }
-            
+
     return \%interfaces;
 }
 
@@ -275,14 +275,14 @@ Jeroen van Ingen Schenau
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $altiga = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'my_vpn_host',
                           Community   => 'public',
                           Version     => 1
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $altiga->class();
@@ -366,7 +366,7 @@ to a hash.
 =item $altiga->interfaces()
 
 This method overrides the interfaces() method inherited from SNMP::Info.
-It provides a mapping between the Interface Table Index (iid) and the physical 
+It provides a mapping between the Interface Table Index (iid) and the physical
 port name, adding a port number to the port name to prevent duplicate names.
 
 =item $altiga->i_lastchange()

--- a/lib/SNMP/Info/Layer3/Arista.pm
+++ b/lib/SNMP/Info/Layer3/Arista.pm
@@ -146,7 +146,7 @@ Bill Fenner
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $arista = new SNMP::Info(
                         AutoSpecify => 1,
                         Debug       => 1,
@@ -154,7 +154,7 @@ Bill Fenner
                         DestHost    => 'myswitch',
                         Community   => 'public',
                         Version     => 2
-                        ) 
+		 	)
     or die "Can't connect to DestHost.\n";
 
  my $class      = $arista->class();

--- a/lib/SNMP/Info/Layer3/Aruba.pm
+++ b/lib/SNMP/Info/Layer3/Aruba.pm
@@ -1403,7 +1403,7 @@ Eric Miller
 			  DestHost    => 'myswitch',
 			  Community   => 'public',
 			  Version     => 2
-			) 
+			)
 
     or die "Can't connect to DestHost.\n";
 
@@ -1422,7 +1422,7 @@ end station MAC addresses collection and correlation to the thin access point
 the end station is using for communication.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $aruba = new SNMP::Info::Layer3::Aruba(...);
 
@@ -1466,7 +1466,7 @@ These are methods that return scalar value from SNMP
 
 =item $aruba->model()
 
-Returns model type.  Cross references $aruba->id() with product IDs in the 
+Returns model type.  Cross references $aruba->id() with product IDs in the
 Aruba MIB.
 
 =item $aruba->vendor()
@@ -1540,7 +1540,7 @@ false.
 =item $aruba->i_ssidmac()
 
 With the same keys as i_ssidlist, returns the Basic service set
-identification (BSSID), MAC address, the AP is using for the SSID. 
+identification (BSSID), MAC address, the AP is using for the SSID.
 
 =item $aruba->cd11_mac()
 
@@ -1578,7 +1578,7 @@ Total packets transmitted by the wireless client.
 
 =item $aruba->i_index()
 
-Returns reference to map of IIDs to Interface index. 
+Returns reference to map of IIDs to Interface index.
 
 Extends C<ifIndex> to support APs as device interfaces.
 
@@ -1614,7 +1614,7 @@ interfaces.
 =item $aruba->i_up_admin()
 
 Returns reference to map of IIDs to administrative status of the interface.
-Returns C<ifAdminStatus> for Ethernet interfaces and C<wlanAPStatus> 
+Returns C<ifAdminStatus> for Ethernet interfaces and C<wlanAPStatus>
 for AP interfaces.
 
 =item $aruba->i_mac()

--- a/lib/SNMP/Info/Layer3/BayRS.pm
+++ b/lib/SNMP/Info/Layer3/BayRS.pm
@@ -1389,14 +1389,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $bayrs = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $bayrs->class();
@@ -1404,10 +1404,10 @@ Eric Miller
 
 =head1 DESCRIPTION
 
-Abstraction subclass for routers running Avaya/Nortel BayRS.  
+Abstraction subclass for routers running Avaya/Nortel BayRS.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $bayrs = new SNMP::Info::Layer3::BayRS(...);
 
@@ -1458,7 +1458,7 @@ These are methods that return scalar value from SNMP
 Returns the model of the BayRS router.  Will translate between the MIB model
 and the common model with this map :
 
-    C<%MODEL_MAP = ( 
+    C<%MODEL_MAP = (
         'acefn'     => 'FN',
         'aceln'     => 'LN',
         'acecn'     => 'CN',
@@ -1529,8 +1529,8 @@ passed but the entire table will be returned.
 Returns reference to the map between IID and physical Port.
 
 The physical port name is stripped to letter and numbers to signify
-port type and slot port (S11) if the default platform naming was 
-maintained.  Otherwise the port is the interface description. 
+port type and slot port (S11) if the default platform naming was
+maintained.  Otherwise the port is the interface description.
 
 =item $bayrs->i_name()
 
@@ -1540,7 +1540,7 @@ interfaces.
 =item $bayrs->i_duplex()
 
 Returns reference to hash.  Maps port operational duplexes to IIDs for
-Ethernet interfaces. 
+Ethernet interfaces.
 
 =item $bayrs->i_duplex_admin()
 

--- a/lib/SNMP/Info/Layer3/BlueCoatSG.pm
+++ b/lib/SNMP/Info/Layer3/BlueCoatSG.pm
@@ -154,12 +154,6 @@ See documentation in L<SNMP::Info::Layer3/"GLOBALS"> for details.
 These are methods that return tables of information in the form of a reference
 to a hash.
 
-=head2 Overrides
-
-=over
-
-=back
-
 =head2 Table Methods imported from SNMP::Info::Layer3
 
 See documentation in L<SNMP::Info::Layer3/"TABLE METHODS"> for details.

--- a/lib/SNMP/Info/Layer3/C3550.pm
+++ b/lib/SNMP/Info/Layer3/C3550.pm
@@ -206,7 +206,7 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $c3550 = new SNMP::Info(
                         AutoSpecify => 1,
                         Debug       => 1,
@@ -214,7 +214,7 @@ Max Baker
                         DestHost    => 'myswitch',
                         Community   => 'public',
                         Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $c3550->class();
@@ -222,14 +222,14 @@ Max Baker
 
 =head1 DESCRIPTION
 
-Abstraction subclass for Cisco Catalyst 3550 Layer 2/3 Switches.  
+Abstraction subclass for Cisco Catalyst 3550 Layer 2/3 Switches.
 
 These devices run IOS but have some of the same characteristics as the
 Catalyst WS-C family (5xxx,6xxx).  For example, forwarding tables are held in
 VLANs, and extended interface information is gleaned from F<CISCO-SWITCH-MIB>.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $c3550 = new SNMP::Info::Layer3::C3550(...);
 
@@ -327,7 +327,7 @@ Crosses $c3550->p_port() with $c3550->p_duplex() to utilize port C<ifIndex>.
 
     Example:
     my %if_map = reverse %{$c3550->interfaces()};
-    $c3550->set_i_duplex_admin('auto', $if_map{'FastEthernet0/1'}) 
+    $c3550->set_i_duplex_admin('auto', $if_map{'FastEthernet0/1'})
         or die "Couldn't change port duplex. ",$c3550->error(1);
 
 =back

--- a/lib/SNMP/Info/Layer3/C4000.pm
+++ b/lib/SNMP/Info/Layer3/C4000.pm
@@ -111,7 +111,7 @@ Bill Fenner
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $c4000 = new SNMP::Info(
                         AutoSpecify => 1,
                         Debug       => 1,
@@ -119,7 +119,7 @@ Bill Fenner
                         DestHost    => 'myswitch',
                         Community   => 'public',
                         Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $c4000->class();
@@ -127,10 +127,10 @@ Bill Fenner
 
 =head1 DESCRIPTION
 
-Abstraction subclass for Cisco Catalyst 4000 Layer 2/3 Switches.  
+Abstraction subclass for Cisco Catalyst 4000 Layer 2/3 Switches.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $c4000 = new SNMP::Info::Layer3::C4000(...);
 

--- a/lib/SNMP/Info/Layer3/C6500.pm
+++ b/lib/SNMP/Info/Layer3/C6500.pm
@@ -179,7 +179,7 @@ sub set_i_duplex_admin {
 
     my $c6500 = shift;
     my ( $duplex, $iid ) = @_;
- 
+
     if ( $c6500->is_virtual_switch() ) {
 
         # VSS -> MAU
@@ -252,7 +252,7 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $c6500 = new SNMP::Info(
                         AutoSpecify => 1,
                         Debug       => 1,
@@ -260,7 +260,7 @@ Max Baker
                         DestHost    => 'myswitch',
                         Community   => 'public',
                         Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $c6500->class();
@@ -268,14 +268,14 @@ Max Baker
 
 =head1 DESCRIPTION
 
-Abstraction subclass for Cisco Catalyst 6500 Layer 2/3 Switches.  
+Abstraction subclass for Cisco Catalyst 6500 Layer 2/3 Switches.
 
 These devices run IOS but have some of the same characteristics as the
 Catalyst WS-C family (5xxx). For example, forwarding tables are held in
 VLANs, and extended interface information is gleaned from F<CISCO-SWITCH-MIB>.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $c6500 = new SNMP::Info::Layer3::C6500(...);
 
@@ -382,7 +382,7 @@ Crosses $c6500->p_port() with $c6500->p_duplex() to utilize port C<ifIndex>.
 
     Example:
     my %if_map = reverse %{$c6500->interfaces()};
-    $c6500->set_i_duplex_admin('auto', $if_map{'FastEthernet0/1'}) 
+    $c6500->set_i_duplex_admin('auto', $if_map{'FastEthernet0/1'})
         or die "Couldn't change port duplex. ",$c6500->error(1);
 
 =item $c6500->set_i_speed_admin(speed, ifIndex)

--- a/lib/SNMP/Info/Layer3/CheckPoint.pm
+++ b/lib/SNMP/Info/Layer3/CheckPoint.pm
@@ -57,7 +57,7 @@ $VERSION = '3.64';
     %SNMP::Info::LLDP::GLOBALS,
     'netsnmp_vers'   => 'versionTag',
     'hrSystemUptime' => 'hrSystemUptime',
-    
+
 );
 
 %FUNCS = (
@@ -109,7 +109,7 @@ sub os_ver {
             return $1 if ($extend_table->{$ex} =~ /^This is Check Point's software version (.*)$/);
             last;
         }
-    } 
+    }
 
     $os_ver = $1 if ( $descr =~ /^\S+\s+\S+\s+(\S+)\s+/ );
     if ($vers) {
@@ -184,14 +184,14 @@ Ambroise Rosset
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $ckp = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $ckp->class();

--- a/lib/SNMP/Info/Layer3/Cisco.pm
+++ b/lib/SNMP/Info/Layer3/Cisco.pm
@@ -189,7 +189,7 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $cisco = new SNMP::Info(
                         AutoSpecify => 1,
                         Debug       => 1,
@@ -197,7 +197,7 @@ Max Baker
                         DestHost    => 'myswitch',
                         Community   => 'public',
                         Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $cisco->class();

--- a/lib/SNMP/Info/Layer3/CiscoFWSM.pm
+++ b/lib/SNMP/Info/Layer3/CiscoFWSM.pm
@@ -196,10 +196,6 @@ See documentation in L<SNMP::Info::Layer3/"GLOBALS"> for details.
 These are methods that return tables of information in the form of a reference
 to a hash.
 
-=over
-
-=back
-
 =head2 Overrides
 
 =over

--- a/lib/SNMP/Info/Layer3/CiscoFWSM.pm
+++ b/lib/SNMP/Info/Layer3/CiscoFWSM.pm
@@ -141,7 +141,7 @@ Brian De Wolf
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $fwsm = new SNMP::Info(
 						AutoSpecify => 1,
 						Debug       => 1,
@@ -149,7 +149,7 @@ Brian De Wolf
 						DestHost    => 'myswitch',
 						Community   => 'public',
 						Version     => 2
-						) 
+						)
 	or die "Can't connect to DestHost.\n";
 
  my $class      = $fwsm->class();

--- a/lib/SNMP/Info/Layer3/CiscoSwitch.pm
+++ b/lib/SNMP/Info/Layer3/CiscoSwitch.pm
@@ -91,7 +91,7 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $switch = new SNMP::Info(
                         AutoSpecify => 1,
                         Debug       => 1,
@@ -99,7 +99,7 @@ Eric Miller
                         DestHost    => 'myswitch',
                         Community   => 'public',
                         Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $switch->class();
@@ -107,14 +107,14 @@ Eric Miller
 
 =head1 DESCRIPTION
 
-Base subclass for Cisco Layer 2/3 Switches.  
+Base subclass for Cisco Layer 2/3 Switches.
 
 These devices have switch specific characteristics beyond those in
 traditional routers covered by L<SNMP::Info::Layer3::Cisco>. For example,
 port security interface information from L<SNMP::Info::CiscoPortSecurity>.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $swich = new SNMP::Info::Layer3::CiscoSwitch(...);
 

--- a/lib/SNMP/Info/Layer3/Contivity.pm
+++ b/lib/SNMP/Info/Layer3/Contivity.pm
@@ -171,14 +171,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $contivity = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $contivity->class();
@@ -187,10 +187,10 @@ Eric Miller
 =head1 DESCRIPTION
 
 Abstraction subclass for Avaya/Nortel VPN Routers (formerly Contivity
-Extranet Switch).  
+Extranet Switch).
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $contivity = new SNMP::Info::Layer3::Contivity(...);
 

--- a/lib/SNMP/Info/Layer3/Cumulus.pm
+++ b/lib/SNMP/Info/Layer3/Cumulus.pm
@@ -115,7 +115,7 @@ sub uptime {
 }
 
 # ifDescr is the same for all interfaces in a class, but the ifName is
-# unique, so let's use that for port name.  If all else fails, 
+# unique, so let's use that for port name.  If all else fails,
 # concatentate ifDesc and ifIndex.
 # (code from SNMP/Info/Layer2/Netgear.pm)
 sub interfaces {
@@ -179,14 +179,14 @@ Oliver Gorwits - based on Layer3::NetSNMP implementation
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $cumulus = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $cumulus->class();

--- a/lib/SNMP/Info/Layer3/DLink.pm
+++ b/lib/SNMP/Info/Layer3/DLink.pm
@@ -47,7 +47,7 @@ $VERSION = '3.64';
     'SWPRIMGMT-DES3200-MIB' => 'dlink-des3200SeriesProd',
     'SWPRIMGMT-DES30XXP-MIB' => 'dlink-des30xxproductProd',
     'SWPRIMGMT-DES1228ME-MIB' => 'dlink-des1228MEproductProd',
-    'SWDES3528-52PRIMGMT-MIB' => 'dlink-Des3500Series', 
+    'SWDES3528-52PRIMGMT-MIB' => 'dlink-Des3500Series',
     'DES-1210-28-AX' => 'des-1210-28ax',
     'DES-1210-10MEbx' => 'des-1210-10mebx',
     'DES-1210-26MEbx' => 'des-1210-26mebx',
@@ -164,14 +164,14 @@ SNMP::Info::Layer3::DLink - SNMP Interface to DLink Devices
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $dlink = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $dlink->class();

--- a/lib/SNMP/Info/Layer3/Dell.pm
+++ b/lib/SNMP/Info/Layer3/Dell.pm
@@ -167,7 +167,7 @@ sub fan {
 
     my $fan   = $dell->dell_fan_desc()  || {};
     my $state = $dell->dell_fan_state() || {};
-    
+
     if (scalar keys %$fan) {
         my @messages = ();
 
@@ -200,8 +200,8 @@ sub ps2_type {
     my $dell = shift;
 
     my $src  = $dell->dell_pwr_src()  || {};
-    
-    my $i = 0; 
+
+    my $i = 0;
     foreach my $k (sort keys %$src) {
         $i++;
         next unless $src->{$k} and $i == 2;
@@ -226,8 +226,8 @@ sub ps2_status {
     my $dell = shift;
 
     my $status  = $dell->dell_pwr_state()  || {};
-    
-    my $i = 0; 
+
+    my $i = 0;
     foreach my $k (sort keys %$status) {
         $i++;
         next unless $status->{$k} and $i == 2;
@@ -330,14 +330,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $dell = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 1
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $dell->class();
@@ -346,12 +346,12 @@ Eric Miller
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from an 
+Provides abstraction to the configuration information obtainable from an
 Dell Power Connect device through SNMP.  D-Link and the IBM BladeCenter
-Gigabit Ethernet Switch Module also use this module based upon MIB support. 
+Gigabit Ethernet Switch Module also use this module based upon MIB support.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
 my $dell = new SNMP::Info::Layer3::Dell(...);
 
@@ -502,7 +502,7 @@ to a hash.
 =item $dell->interfaces()
 
 Returns the map between SNMP Interface Identifier (iid) and physical port
-name.  Uses name if available instead of description since descriptions are 
+name.  Uses name if available instead of description since descriptions are
 sometimes not unique.
 
 =item $dell->i_duplex()

--- a/lib/SNMP/Info/Layer3/Enterasys.pm
+++ b/lib/SNMP/Info/Layer3/Enterasys.pm
@@ -207,7 +207,7 @@ sub lldp_if {
     my $addr    = $lldp->lldp_rem_pid($partial) || {};
     my $i_descr = $lldp->ifName() || {};
     my %r_i_descr = reverse %$i_descr;
-    
+
     my %lldp_if;
     foreach my $key ( keys %$addr ) {
         my @aOID = split( '\.', $key );
@@ -221,7 +221,7 @@ sub lldp_if {
         if ( exists $r_i_descr{$desc} ) {
             $port = $r_i_descr{$desc};
         }
-        
+
         $lldp_if{$key} = $port;
     }
     return \%lldp_if;
@@ -261,14 +261,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $enterasys = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 1
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $enterasys->class();
@@ -277,11 +277,11 @@ Eric Miller
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from an 
-Enterasys device through SNMP. 
+Provides abstraction to the configuration information obtainable from an
+Enterasys device through SNMP.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
 my $enterasys = new SNMP::Info::Layer3::Enterasys(...);
 

--- a/lib/SNMP/Info/Layer3/Extreme.pm
+++ b/lib/SNMP/Info/Layer3/Extreme.pm
@@ -294,9 +294,9 @@ sub fan {
 # default is slot * 1000, but some older switches start at 1
 sub _slot_factor {
     my $extreme = shift;
-    
+
     my $index = $extreme->i_index();
-    
+
     return 1 if (exists $index->{1} && $index->{1} == 1);
     return 1000;
 }
@@ -306,7 +306,7 @@ sub _slot_factor {
 # we use the BRIDGE-MIB tables if available then the ex_fw_*() methods.
 sub fw_mac {
     my $extreme = shift;
-    
+
     my $b = $extreme->SUPER::fw_mac();
     return $b if (keys %$b);
 
@@ -315,10 +315,10 @@ sub fw_mac {
 
 sub fw_port {
     my $extreme = shift;
-    
+
     my $b = $extreme->SUPER::fw_port();
     return $b if (keys %$b);
-    
+
     return $extreme->ex_fw_port();
 }
 
@@ -402,11 +402,11 @@ sub i_vlan {
     # Next we try extremeVlanOpaqueTable
     my $xos = $extreme->_xos_i_vlan($partial);
     return $xos if (keys %$xos);
-    
+
     # Try older ifStack method
     my $extremeware = $extreme->_extremeware_i_vlan($partial);
     return $extremeware if (keys %$extremeware);
-    
+
     return;
 }
 
@@ -481,11 +481,11 @@ sub i_vlan_membership {
     # Next we try extremeVlanOpaqueTable
     my $xos = $extreme->_xos_i_vlan_membership($partial);
     return $xos if (ref {} eq ref $xos and scalar keys %$xos);
-    
+
     # Try older ifStack method
     my $extremeware = $extreme->_extremeware_i_vlan_membership($partial);
     return $extremeware if (ref {} eq ref $extremeware and scalar keys %$extremeware);
-    
+
     return;
 }
 
@@ -573,11 +573,11 @@ sub i_vlan_membership_untagged {
     # Next we try extremeVlanOpaqueTable
     my $xos = $extreme->_xos_i_vlan_membership_untagged($partial);
     return $xos if (ref {} eq ref $xos and scalar keys %$xos);
-    
+
     # Try older ifStack method
     my $extremeware = $extreme->_extremeware_i_vlan_membership_untagged($partial);
     return $extremeware if (ref {} eq ref $extremeware and scalar keys %$extremeware);
-    
+
     return;
 }
 
@@ -789,7 +789,7 @@ sub lldp_if {
     my $addr    = $extreme->lldp_rem_pid($partial) || {};
     my $b_index = $extreme->bp_index() || {};
     #my %r_i_descr = reverse %$i_descr;
-    
+
     my %lldp_if;
     foreach my $key ( keys %$addr ) {
         my @aOID = split( '\.', $key );
@@ -829,9 +829,9 @@ sub stp_i_mac {
     foreach my $iid ( keys %$stp_i_bids ) {
         my $mac = $stp_i_bids->{$iid};
         next unless $mac;
-        
+
         $mac =~ s/^([0-9A-F][0-9A-F]:){2}//;
-        
+
         $stp_i_mac{$iid} = $mac;
     }
     return \%stp_i_mac;
@@ -886,14 +886,14 @@ Eric Miller, Bill Fenner
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $extreme = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 1
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $extreme->class();
@@ -902,11 +902,11 @@ Eric Miller, Bill Fenner
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from an 
-Extreme device through SNMP. 
+Provides abstraction to the configuration information obtainable from an
+Extreme device through SNMP.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
 my $extreme = new SNMP::Info::Layer3::Extreme(...);
 
@@ -1081,7 +1081,7 @@ IDs.  These are the VLANs which are members of the egress list for the port.
   Example:
   my $interfaces = $extreme->interfaces();
   my $vlans      = $extreme->i_vlan_membership();
-  
+
   foreach my $iid (sort keys %$interfaces) {
     my $port = $interfaces->{$iid};
     my $vlan = join(',', sort(@{$vlans->{$iid}}));
@@ -1239,7 +1239,7 @@ See documentation in L<SNMP::Info::EDP/"TABLE METHODS"> for details.
 These are methods that provide SNMP set functionality for overridden methods
 or provide a simpler interface to complex set operations.  See
 L<SNMP::Info/"SETTING DATA VIA SNMP"> for general information on set
-operations. 
+operations.
 
 =over
 
@@ -1251,7 +1251,7 @@ VLAN ID and port C<ifIndex>.  This method should only be used on end station
 
   Example:
   my %if_map = reverse %{$extreme->interfaces()};
-  $extreme->set_i_vlan('2', $if_map{'FastEthernet0/1'}) 
+  $extreme->set_i_vlan('2', $if_map{'FastEthernet0/1'})
     or die "Couldn't change port VLAN. ",$extreme->error(1);
 
 =item $extreme->set_i_pvid ( pvid, ifIndex )
@@ -1261,7 +1261,7 @@ port C<ifIndex>.  This method should only be used on trunk ports.
 
   Example:
   my %if_map = reverse %{$extreme->interfaces()};
-  $extreme->set_i_pvid('2', $if_map{'FastEthernet0/1'}) 
+  $extreme->set_i_pvid('2', $if_map{'FastEthernet0/1'})
     or die "Couldn't change port default VLAN. ",$extreme->error(1);
 
 =item $extreme->set_add_i_vlan_tagged ( vlan, ifIndex )
@@ -1271,7 +1271,7 @@ numeric VLAN ID and port C<ifIndex>.
 
   Example:
   my %if_map = reverse %{$extreme->interfaces()};
-  $extreme->set_add_i_vlan_tagged('2', $if_map{'FastEthernet0/1'}) 
+  $extreme->set_add_i_vlan_tagged('2', $if_map{'FastEthernet0/1'})
     or die "Couldn't add port to egress list. ",$extreme->error(1);
 
 =item $extreme->set_remove_i_vlan_tagged ( vlan, ifIndex )
@@ -1281,7 +1281,7 @@ with the numeric VLAN ID and port C<ifIndex>.
 
   Example:
   my %if_map = reverse %{$extreme->interfaces()};
-  $extreme->set_remove_i_vlan_tagged('2', $if_map{'FastEthernet0/1'}) 
+  $extreme->set_remove_i_vlan_tagged('2', $if_map{'FastEthernet0/1'})
     or die "Couldn't add port to egress list. ",$extreme->error(1);
 
 =back

--- a/lib/SNMP/Info/Layer3/F5.pm
+++ b/lib/SNMP/Info/Layer3/F5.pm
@@ -270,7 +270,7 @@ sub i_vlan_membership_untagged {
 
     my $i_vlan_membership = {};
     foreach my $iid ( keys %$tagged ) {
-        
+
         next unless $tagged->{$iid} eq 'false';
         # IID is length.vlan name index.length.interface index
         # Split out and use as the IID to get the VLAN ID and ifIndex
@@ -304,14 +304,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $f5 = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $f5->class();
@@ -322,7 +322,7 @@ Eric Miller
 Abstraction subclass for F5 network devices.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $f5 = new SNMP::Info::Layer3::F5(...);
 
@@ -357,7 +357,7 @@ These are methods that return scalar value from SNMP
 =item $f5->model()
 
 Return (C<sysPlatformInfoMarketingName>), otherwise tries to reference
-$f5->id() to F<F5-BIGIP-COMMON-MIB>. 
+$f5->id() to F<F5-BIGIP-COMMON-MIB>.
 
 =item $f5->vendor()
 
@@ -420,7 +420,7 @@ IDs.
   Example:
   my $interfaces = $f5->interfaces();
   my $vlans      = $f5->i_vlan_membership();
-  
+
   foreach my $iid (sort keys %$interfaces) {
     my $port = $interfaces->{$iid};
     my $vlan = join(',', sort(@{$vlans->{$iid}}));

--- a/lib/SNMP/Info/Layer3/Force10.pm
+++ b/lib/SNMP/Info/Layer3/Force10.pm
@@ -122,7 +122,7 @@ sub i_vlan {
 }
 
 # Apparently index doesn't use VLAN ID, so override the HOA private
-# method here to correct the mapping 
+# method here to correct the mapping
 sub _vlan_hoa {
     my $force10 = shift;
     my ( $v_ports, $partial ) = @_;
@@ -153,7 +153,7 @@ sub _vlan_hoa {
             my $vlan_tag = $v_index->{$vlan_ndx};
 
             # FIXME: would be preferable to use
-            # the mapping from Q-BRIDGE-MIB::dot1qVlanFdbId 
+            # the mapping from Q-BRIDGE-MIB::dot1qVlanFdbId
             my $mod = $vlan_tag % 4096;
 
             push ( @{ $vlan_hoa->{$ifindex} }, ($mod) );
@@ -176,7 +176,7 @@ William Bulley
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $force10 = new SNMP::Info(
                         AutoSpecify => 1,
                         Debug       => 1,
@@ -184,7 +184,7 @@ William Bulley
                         DestHost    => 'myswitch',
                         Community   => 'public',
                         Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $force10->class();

--- a/lib/SNMP/Info/Layer3/Fortinet.pm
+++ b/lib/SNMP/Info/Layer3/Fortinet.pm
@@ -81,19 +81,19 @@ sub os {
 
 sub os_ver {
     my $fortinet = shift;
-    
+
     my $ver = $fortinet->fgSysVersion() || '';
 
     if ( $ver =~ /(\d+[\.\d]+)/ ) {
         return $1;
     }
-    
+
     return $ver;
 }
 
 sub serial {
     my $fortinet = shift;
-    
+
     return $fortinet->fnSysSerial();
 }
 
@@ -110,14 +110,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $fortinet = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $fortinet->class();
@@ -128,7 +128,7 @@ Eric Miller
 Abstraction subclass for Fortinet network devices.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $fortinet = new SNMP::Info::Layer3::Fortinet(...);
 

--- a/lib/SNMP/Info/Layer3/Foundry.pm
+++ b/lib/SNMP/Info/Layer3/Foundry.pm
@@ -241,7 +241,7 @@ sub os_ver {
 
     # See if we report from Flash if wouldn't report from running above
     return $foundry->snAgFlashImgVer() if ( defined $foundry->snAgFlashImgVer() );
-    
+
     # Last resort
     return $foundry->SUPER::os_ver();
 
@@ -405,7 +405,7 @@ sub brcd_e_index {
     my $partial = shift;
 
     my $stack_master = $foundry->_brcd_stack_master();
-    my $brcd_e_idx 
+    my $brcd_e_idx
         = $foundry->snAgentConfigModule2Description($partial)
         || $foundry->snAgentConfigModuleDescription($partial)
         || {};
@@ -460,7 +460,7 @@ sub brcd_e_descr {
     my $partial = shift;
 
     my $brcd_e_idx = $foundry->brcd_e_index($partial) || {};
-    my $m_descrs 
+    my $m_descrs
         = $foundry->snAgentConfigModule2Description($partial)
         || $foundry->snAgentConfigModuleDescription($partial)
         || {};
@@ -526,7 +526,7 @@ sub brcd_e_serial {
     my $partial = shift;
 
     my $e_idx = $foundry->brcd_e_index($partial) || {};
-    my $serials 
+    my $serials
         = $foundry->snAgentConfigModule2SerialNumber($partial)
         || $foundry->snAgentConfigModuleSerialNumber($partial)
         || {};
@@ -551,7 +551,7 @@ sub brcd_e_type {
     my $partial = shift;
 
     my $e_idx = $foundry->brcd_e_index($partial) || {};
-    my $types 
+    my $types
         = $foundry->ag_mod2_type($partial)
         || $foundry->ag_mod_type($partial)
         || {};
@@ -861,14 +861,14 @@ Max Baker
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $foundry = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 1
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $foundry->class();
@@ -932,7 +932,7 @@ These are methods that return scalar value from SNMP
 
 Returns model type.  Checks $foundry->id() against the F<FOUNDRY-SN-ROOT-MIB>
 and removes 'C<sn>' and 'C<Switch>'.  EdgeIron models determined
-through F<ENTITY-MIB>.  
+through F<ENTITY-MIB>.
 
 =item $foundry->vendor()
 
@@ -1029,16 +1029,16 @@ Returns reference to hash of interface names to iids.
 
 Returns reference to hash of interfaces to be ignored.
 
-Ignores interfaces with descriptions of  tunnel,loopback,null 
+Ignores interfaces with descriptions of  tunnel,loopback,null
 
 =item $foundry->i_duplex()
 
-Returns reference to hash of interface link duplex status. 
+Returns reference to hash of interface link duplex status.
 
 Crosses $foundry->sw_duplex() with $foundry->sw_index()
 
 =item $foundry->i_stp_state()
- 
+
 Returns the mapping of (C<dot1dStpPortState>) to the interface
 index (iid).
 
@@ -1060,7 +1060,7 @@ for details on brcd_e_* methods.
 
 =over
 
-=item $foundry->e_index() 
+=item $foundry->e_index()
 
 If the device doesn't support C<entPhysicalDescr>, this will
 try brcd_e_index().
@@ -1068,42 +1068,42 @@ try brcd_e_index().
 Note that this is based on C<entPhysicalDescr> due to implementation
 details of SNMP::Info::Entity::e_index().
 
-=item $foundry->e_class() 
+=item $foundry->e_class()
 
 If the device doesn't support C<entPhysicalClass>, this will try
 brcd_e_class().
 
-=item $foundry->e_descr() 
+=item $foundry->e_descr()
 
 If the device doesn't support C<entPhysicalDescr>, this will try
 brcd_e_descr().
 
-=item $foundry->e_name() 
+=item $foundry->e_name()
 
 If the device doesn't support C<entPhysicalName>, this will try
 brcd_e_name().
 
-=item $foundry->e_parent() 
+=item $foundry->e_parent()
 
 If the device doesn't support C<entPhysicalContainedIn>, this will try
 brcd_e_parent().
 
-=item $foundry->e_pos() 
+=item $foundry->e_pos()
 
 If the device doesn't support C<entPhysicalParentRelPos>, this will try
 brcd_e_pos().
 
-=item $foundry->e_serial() 
+=item $foundry->e_serial()
 
 If the device doesn't support C<entPhysicalSerialNum>, this will try
 brcd_e_serial().
 
-=item $foundry->e_type() 
+=item $foundry->e_type()
 
 If the device doesn't support C<entPhysicalVendorType>, this will try
 brcd_e_type().
 
-=item $foundry->e_vendor() 
+=item $foundry->e_vendor()
 
 If the device doesn't support C<entPhysicalMfgName>, this will try
 brcd_e_vendor().
@@ -1113,7 +1113,7 @@ brcd_e_vendor().
 =head2 Pseudo F<ENTITY-MIB> information
 
 These methods emulate F<ENTITY-MIB> Physical Table methods using
-F<FOUNDRY-SN-AGENT-MIB>. 
+F<FOUNDRY-SN-AGENT-MIB>.
 
 =over
 
@@ -1135,7 +1135,7 @@ base switches that contain modules, and 'module' for others.
 Returns reference to hash.  Key: IID, Value: Human friendly name
 
 (C<snAgentConfigModule2Description>) or
-(C<snAgentConfigModuleDescription>) 
+(C<snAgentConfigModuleDescription>)
 
 =item $foundry->brcd_e_name()
 
@@ -1149,14 +1149,14 @@ Returns reference to hash.  Key: IID, Value: brocade
 
 Returns reference to hash.  Key: IID, Value: Serial number
 
-Serial number is $foundry->serial() for a stack master unit and 
+Serial number is $foundry->serial() for a stack master unit and
 (C<snAgentConfigModule2SerialNumber>) or
 (C<snAgentConfigModuleSerialNumber>) for all others.
 
 =item $foundry->brcd_e_type()
 
 Returns reference to hash.  Key: IID, Value: Type of component/sub-component
-as defined under C<snAgentConfigModule2Type> or C<snAgentConfigModule2Type> 
+as defined under C<snAgentConfigModule2Type> or C<snAgentConfigModule2Type>
 in F<FOUNDRY-SN-AGENT-MIB>.
 
 =item $foundry->brcd_e_pos()
@@ -1180,13 +1180,13 @@ this entity is not contained in any other entity.
 
 =item $foundry->sw_index()
 
-Returns reference to hash.  Maps Table to Interface IID. 
+Returns reference to hash.  Maps Table to Interface IID.
 
 (C<snSwPortIfIndex>)
 
 =item $foundry->sw_duplex()
 
-Returns reference to hash.   Current duplex status for switch ports. 
+Returns reference to hash.   Current duplex status for switch ports.
 
 (C<snSwPortInfoChnMode>)
 
@@ -1198,7 +1198,7 @@ Returns reference to hash.  Current Port Type .
 
 =item $foundry->sw_speed()
 
-Returns reference to hash.  Current Port Speed. 
+Returns reference to hash.  Current Port Speed.
 
 (C<snSwPortInfoSpeed>)
 

--- a/lib/SNMP/Info/Layer3/Genua.pm
+++ b/lib/SNMP/Info/Layer3/Genua.pm
@@ -115,14 +115,14 @@ Netdisco Developers
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $genua = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myhub',
                           Community   => 'public',
                           Version     => 1
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $genua->class();
@@ -163,7 +163,7 @@ Returns 'genua'
 
 =item $genua->os_ver()
 
-(C<infoRelease>) and (C<infoPatchlevel>) 
+(C<infoRelease>) and (C<infoPatchlevel>)
 
 =item $genua->model()
 

--- a/lib/SNMP/Info/Layer3/H3C.pm
+++ b/lib/SNMP/Info/Layer3/H3C.pm
@@ -89,7 +89,7 @@ sub vendor {
 
 sub model {
     my $h3c = shift;
-    
+
     my $descr = $h3c->description();
     if ($descr =~ /^.*\n(.*)\n/) {
         return $1;
@@ -154,14 +154,14 @@ Jeroen van Ingen
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $h3c = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $h3c->class();
@@ -223,7 +223,7 @@ Returns the OS extracted from C<sysDescr>.
 
 =item $h3c->os_ver()
 
-Returns the software version. Either C<entPhysicalSoftwareRev.2> or extracted from 
+Returns the software version. Either C<entPhysicalSoftwareRev.2> or extracted from
 C<sysDescr>.
 
 =back

--- a/lib/SNMP/Info/Layer3/HP9300.pm
+++ b/lib/SNMP/Info/Layer3/HP9300.pm
@@ -209,14 +209,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $hp9300 = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 1
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $hp9300->class();
@@ -359,11 +359,11 @@ Returns reference to hash of interface names to iids.
 
 Returns reference to hash of interfaces to be ignored.
 
-Ignores interfaces with descriptions of  tunnel,loopback,null 
+Ignores interfaces with descriptions of  tunnel,loopback,null
 
 =item $hp9300->i_duplex()
 
-Returns reference to hash of interface link duplex status. 
+Returns reference to hash of interface link duplex status.
 
 Crosses $hp9300->sw_duplex() with $hp9300->sw_index()
 
@@ -375,13 +375,13 @@ Crosses $hp9300->sw_duplex() with $hp9300->sw_index()
 
 =item $hp9300->sw_index()
 
-Returns reference to hash.  Maps Table to Interface IID. 
+Returns reference to hash.  Maps Table to Interface IID.
 
 (C<snSwPortIfIndex>)
 
 =item $hp9300->sw_duplex()
 
-Returns reference to hash.   Current duplex status for switch ports. 
+Returns reference to hash.   Current duplex status for switch ports.
 
 (C<snSwPortInfoChnMode>)
 
@@ -393,7 +393,7 @@ Returns reference to hash.  Current Port Type .
 
 =item $hp9300->sw_speed()
 
-Returns reference to hash.  Current Port Speed. 
+Returns reference to hash.  Current Port Speed.
 
 (C<snSwPortInfoSpeed>)
 

--- a/lib/SNMP/Info/Layer3/Huawei.pm
+++ b/lib/SNMP/Info/Layer3/Huawei.pm
@@ -138,7 +138,7 @@ sub os_ver {
     if ($descr =~ /Version\s            # Start match on Version string
                    ([\d\.]+)            # Capture the primary version in 1
                    ,?                   # There may be a comma
-                   \s                   # Always a space                     
+                   \s                   # Always a space
                    (?:Release|Feature)? # Don't capture stanza if present
                    (?:\(\w+)?           # If paren & model don't capture
                    \s                   # Always a space
@@ -154,7 +154,7 @@ sub os_ver {
 
 sub mac {
     my $huawei  = shift;
-    
+
     return $huawei->b_mac();
 }
 
@@ -393,7 +393,7 @@ sub fan {
             my ($slot, $num) = split(/\./, $k);
             my $descr = "Slot $slot,Fan $num";
             $descr = $fan->{$k} if ($fan->{$k});
-            
+
             push @messages, "$descr: $state->{$k}";
         }
 
@@ -511,14 +511,14 @@ Jeroen van Ingen and Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $huawei = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $huawei->class();
@@ -553,7 +553,7 @@ Subclass for Huawei switches
 =item F<HUAWEI-POE-MIB>
 
 =item F<HUAWEI-ENTITY-EXTENT-MIB>
-    
+
 =item Inherited Classes' MIBs
 
 See L<SNMP::Info::Layer3> for its own MIB requirements.

--- a/lib/SNMP/Info/Layer3/IBMGbTor.pm
+++ b/lib/SNMP/Info/Layer3/IBMGbTor.pm
@@ -248,14 +248,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $ibm = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 1
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $ibm->class();
@@ -335,7 +335,7 @@ Returns the software version
 
 =item $ibm->hasLLDP()
 
-Is LLDP is active in this device?  
+Is LLDP is active in this device?
 
 Note:  LLDP may be active, but nothing in C<lldpRemoteSystemsData> Tables so
 the device would not return any useful topology information.
@@ -373,13 +373,13 @@ Ignores interfaces with descriptions of tunnel, loopback, and null.
 
 =item $ibm->i_duplex()
 
-Returns reference to hash of interface link duplex status. 
+Returns reference to hash of interface link duplex status.
 
 (C<portInfoMode>)
 
 =item $ibm->lldp_if()
 
-Returns the mapping to the SNMP Interface Table. Tries to cross reference 
+Returns the mapping to the SNMP Interface Table. Tries to cross reference
 (C<lldpInfoRemoteDevicesLocalPort>) with (C<ifDescr>) and (C<ifAlias>)
 to get (C<ifIndex>).
 

--- a/lib/SNMP/Info/Layer3/Juniper.pm
+++ b/lib/SNMP/Info/Layer3/Juniper.pm
@@ -106,11 +106,11 @@ sub os {
 
 sub layers {
     my $juniper = shift;
-    
+
     my $layers = $juniper->SUPER::layers();
-    # Some models don't report L2 properly 
+    # Some models don't report L2 properly
     my $macs   = $juniper->fw_mac();
-    
+
     if (keys %$macs) {
         my $l = substr $layers, 6, 1, "1";
     }
@@ -145,7 +145,7 @@ sub model {
     # Query the junos device model.
     my $mod = uc $l3->vc_model() || '';
 
-    if  (not $mod eq '') { 
+    if  (not $mod eq '') {
         return $mod;
     }
     # Fallback to old method
@@ -268,14 +268,14 @@ sub i_vlan {
     return $i_vlan;
 }
 
-sub v_name { 
+sub v_name {
     my $juniper = shift;
 
     return $juniper->jnx_els_v_name() || $juniper->jnx_v_name();
 }
 
 # Index doesn't use VLAN ID, so override the HOA private method here to
-# correct the mapping 
+# correct the mapping
 sub _vlan_hoa {
     my $juniper = shift;
     my ( $v_ports, $partial ) = @_;
@@ -373,7 +373,7 @@ sub _e_is_virtual {
     my $juniper = shift;
 
     my $v_test = $juniper->jnxVirtualChassisMemberRole() || {};
-    
+
     #If we are functioning as a stack someone should be master
     foreach my $iid ( keys %$v_test ) {
 	my $role = $v_test->{$iid};
@@ -418,7 +418,7 @@ sub e_index {
     my $virtuals   = $juniper->_e_virtual_index() || {};
     my $is_virtual = $juniper->_e_is_virtual();
 
-    # Format into consistent integer format so that numeric sorting works     
+    # Format into consistent integer format so that numeric sorting works
     my %e_index;
     if ($is_virtual) {
 	foreach my $key ( keys %$virtuals ) {
@@ -433,7 +433,7 @@ sub e_index {
     foreach my $key ( keys %$contents ) {
 	$e_index{$key} = join( '', map { sprintf "%02d", $_ } split /\./, $key );
     }
- 
+
     return \%e_index;
 }
 
@@ -687,14 +687,14 @@ Bill Fenner
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $juniper = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $juniper->class();
@@ -812,7 +812,7 @@ to a hash.
 =item $juniper->qb_fdb_index()
 
 Returns reference to hash: key = FDB ID, value = VLAN ID.
-    
+
 =item $juniper->v_index()
 
 Returns (C<jnxL2aldVlanTag>) or (C<jnxExVlanTag>) depending upon switch
@@ -859,7 +859,7 @@ For example, ge-0/0/1 registers as PowerEthernet interface '1.2'
 =head2 Pseudo F<ENTITY-MIB> information
 
 These methods emulate F<ENTITY-MIB> Physical Table methods using
-F<JUNIPER-MIB> and F<JUNIPER-VIRTUALCHASSIS-MIB>. 
+F<JUNIPER-MIB> and F<JUNIPER-VIRTUALCHASSIS-MIB>.
 
 =over
 

--- a/lib/SNMP/Info/Layer3/Lantronix.pm
+++ b/lib/SNMP/Info/Layer3/Lantronix.pm
@@ -246,10 +246,6 @@ See documentation in L<SNMP::Info::Layer3/"GLOBALS"> for details.
 These are methods that return tables of information in the form of a reference
 to a hash.
 
-=over
-
-=back
-
 =head2 Overrides
 
 =over

--- a/lib/SNMP/Info/Layer3/Lantronix.pm
+++ b/lib/SNMP/Info/Layer3/Lantronix.pm
@@ -113,7 +113,7 @@ sub serial {
     $serial = $1 if ( $descr =~ m/Lantronix EDS\w+ V[\d\.R]+ \((\w+)\)/ );
 
     return $serial;
-}       
+}
 
 sub model {
     my $device = shift;
@@ -162,14 +162,14 @@ J R Binks
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $device = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'mydevice',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $device->class();

--- a/lib/SNMP/Info/Layer3/Microsoft.pm
+++ b/lib/SNMP/Info/Layer3/Microsoft.pm
@@ -104,14 +104,14 @@ begemot
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $router = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 1
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $router->class();

--- a/lib/SNMP/Info/Layer3/Mikrotik.pm
+++ b/lib/SNMP/Info/Layer3/Mikrotik.pm
@@ -179,6 +179,7 @@ Returns the value of C<mtxrLicVersion>.
 Returns the value of RouterOS level C<mtxrLicLevel>
 
 =item $mikrotik->board_temp()
+
 =item $mikrotik->cpu_temp()
 
 Returns the appropriate temperature values
@@ -206,13 +207,8 @@ to a hash.
 
 None.
 
-=over
-
-=back
-
 =head2 Table Methods imported from SNMP::Info::Layer3
 
 See documentation in L<SNMP::Info::Layer3> for details.
-
 
 =cut

--- a/lib/SNMP/Info/Layer3/Mikrotik.pm
+++ b/lib/SNMP/Info/Layer3/Mikrotik.pm
@@ -113,14 +113,14 @@ initial version based on SNMP::Info::Layer3::NetSNMP by Bradley Baetz and Bill F
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $mikrotik = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $mikrotik->class();

--- a/lib/SNMP/Info/Layer3/N1600.pm
+++ b/lib/SNMP/Info/Layer3/N1600.pm
@@ -183,14 +183,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $n1600 = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 1
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $n1600->class();
@@ -200,10 +200,10 @@ Eric Miller
 =head1 DESCRIPTION
 
 Provides abstraction to the configuration information obtainable from an
-Avaya/Nortel N16XX device through SNMP. 
+Avaya/Nortel N16XX device through SNMP.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
 my $n1600 = new SNMP::Info::Layer3::N1600(...);
 
@@ -243,7 +243,7 @@ Return C<1>.  Bulkwalk is currently turned off for this class.
 
 =item $n1600->model()
 
-Returns model type.  Checks $n1600->id() against the 
+Returns model type.  Checks $n1600->id() against the
 F<RAPID-CITY-MIB> and then parses out C<rcA>.
 
 =item $n1600->vendor()
@@ -300,11 +300,11 @@ SNMP::Info::SONMP.
 
 =item $n1600->i_duplex()
 
-Returns reference to hash of interface operational link duplex status. 
+Returns reference to hash of interface operational link duplex status.
 
 =item $n1600->i_duplex_admin()
 
-Returns reference to hash of interface administrative link duplex status. 
+Returns reference to hash of interface administrative link duplex status.
 
 =back
 

--- a/lib/SNMP/Info/Layer3/NetSNMP.pm
+++ b/lib/SNMP/Info/Layer3/NetSNMP.pm
@@ -143,14 +143,14 @@ Bradley Baetz and Bill Fenner
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $netsnmp = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $netsnmp->class();

--- a/lib/SNMP/Info/Layer3/Netscreen.pm
+++ b/lib/SNMP/Info/Layer3/Netscreen.pm
@@ -277,7 +277,7 @@ sub i_up_admin {
     my %i_up_admin;
 
     foreach my $iid ( keys %$ns_i_map ) {
-        $i_up_admin{$iid} 
+        $i_up_admin{$iid}
             = $i_up->{$iid} eq "up" && "up"
             || $i_up_admin->{ $ns_i_map->{$iid} }
             || 0;
@@ -324,7 +324,7 @@ sub i_speed {
     my %i_speed;
 
     foreach my $iid ( keys %$ns_i_map ) {
-        $i_speed{$iid} 
+        $i_speed{$iid}
             = $i_speed->{ $ns_i_map->{$iid} }
             || $i_name->{$iid} =~ /tunnel/ && "vpn"
             || 0;
@@ -527,7 +527,7 @@ Kent Hamilton
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
 
     or die "Can't connect to DestHost.\n";
 
@@ -536,11 +536,11 @@ Kent Hamilton
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from a 
+Provides abstraction to the configuration information obtainable from a
 Juniper Netscreen devices through SNMP.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
 my $netscreen = new SNMP::Info::Layer3::Netscreen(...);
 
@@ -610,7 +610,7 @@ Returns serial number.
 
 =item $netscreen->layers()
 
-Returns 01001110.  Device doesn't report layers properly, modified to reflect 
+Returns 01001110.  Device doesn't report layers properly, modified to reflect
 Layer 2 and 3 functionality.
 
 =back
@@ -641,7 +641,7 @@ name.
 
 Defaults to C<insIfDescr> if available, uses C<nsIfName> if not.
 
-=item $netscreen->i_description() 
+=item $netscreen->i_description()
 
 Description of the interface. Uses C<insIfDescr> if available, C<nsIfName>
 if not.
@@ -658,12 +658,12 @@ Default SNMP IID to Interface index.
 
 =item $netscreen->i_lastchange()
 
-The value of C<sysUpTime> when this port last changed states (up,down), 
+The value of C<sysUpTime> when this port last changed states (up,down),
 maps from C<ifIndex> to C<nsIfIndex>.
 
 (C<ifLastChange>)
 
-=item $netscreen->i_mac() 
+=item $netscreen->i_mac()
 
 MAC address of the interface.  Note this is just the MAC of the port, not
 anything connected to it.  Uses C<nsIfMAC> if available, C<ifPhysAddress>
@@ -691,7 +691,7 @@ Interface type.  Maps from C<ifIndex> to C<nsIfIndex>.
 
 (C<ifType>)
 
-=item $netscreen->i_up() 
+=item $netscreen->i_up()
 
 Link Status of the interface.  Typical values are 'up' and 'down'.
 
@@ -732,7 +732,7 @@ Gives netmask setting for IP table entry.
 
 Uses C<nsIpArpTable> to emulate the forwarding table.
 
-=over 
+=over
 
 =item $netscreen->fw_index()
 
@@ -760,21 +760,21 @@ identifier (IID).
 
 =item $netscreen->at_index()
 
-Returns reference to hash.  Maps ARP table entries to Interface IIDs 
+Returns reference to hash.  Maps ARP table entries to Interface IIDs
 
 If the device doesn't support C<ipNetToMediaIfIndex>, this will try
 the proprietary C<nsIpArpIfIdx>.
 
 =item $netscreen->at_paddr()
 
-Returns reference to hash.  Maps ARP table entries to MAC addresses. 
+Returns reference to hash.  Maps ARP table entries to MAC addresses.
 
 If the device doesn't support C<ipNetToMediaPhysAddress>, this will try
 the proprietary C<nsIpArpMac>.
 
 =item $netscreen->at_netaddr()
 
-Returns reference to hash.  Maps ARP table entries to IP addresses. 
+Returns reference to hash.  Maps ARP table entries to IP addresses.
 
 If the device doesn't support C<ipNetToMediaNetAddress>, this will try
 the proprietary C<nsIpArpIp>.
@@ -783,7 +783,7 @@ the proprietary C<nsIpArpIp>.
 
 =head3 Wireless Information
 
-=over 
+=over
 
 =item $dot11->i_ssidlist()
 

--- a/lib/SNMP/Info/Layer3/Nexus.pm
+++ b/lib/SNMP/Info/Layer3/Nexus.pm
@@ -65,8 +65,8 @@ $VERSION = '3.64';
 	'mac' => 'dot1dBaseBridgeAddress',
 );
 
-%FUNCS = ( 
-    %SNMP::Info::Layer3::CiscoSwitch::FUNCS, 
+%FUNCS = (
+    %SNMP::Info::Layer3::CiscoSwitch::FUNCS,
     'vrf_name' => 'cContextMappingVrfName',
 );
 
@@ -258,7 +258,7 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $nexus = new SNMP::Info(
 						AutoSpecify => 1,
 						Debug       => 1,
@@ -266,7 +266,7 @@ Eric Miller
 						DestHost    => 'myswitch',
 						Community   => 'public',
 						Version     => 2
-						) 
+						)
 	or die "Can't connect to DestHost.\n";
 
  my $class      = $nexus->class();
@@ -274,10 +274,10 @@ Eric Miller
 
 =head1 DESCRIPTION
 
-Abstraction subclass for Cisco Nexus Switches running NX-OS.  
+Abstraction subclass for Cisco Nexus Switches running NX-OS.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $nexus = new SNMP::Info::Layer3::Nexus(...);
 
@@ -340,12 +340,12 @@ C<dot1dBaseBridgeAddress>
 
 =head3 IP Address Table
 
-Each entry in this table is an IP address in use on this device.  Some 
+Each entry in this table is an IP address in use on this device.  Some
 versions do not index the table with the IPv4 address in accordance with
 the MIB definition, these overrides correct that behavior.
 
-Also, the table is augmented with IP addresses in use by UDP sockets on the 
-device, as determined by checking F<RFC1213-MIB::udpLocalAddress>. Valid 
+Also, the table is augmented with IP addresses in use by UDP sockets on the
+device, as determined by checking F<RFC1213-MIB::udpLocalAddress>. Valid
 addresses from this table (any IPv4 that is not localhost, 0.0.0.0, Class D
 (multicast) or Class E (experimental) are added as a /32 on interface ID 0.
 This is a workaround to determine possible VPC Keepalive IP addresses on the

--- a/lib/SNMP/Info/Layer3/PacketFront.pm
+++ b/lib/SNMP/Info/Layer3/PacketFront.pm
@@ -110,12 +110,12 @@ sub i_ignore {
 
 sub layers {
     my $pfront = shift;
-    
+
     my $layers = $pfront->SUPER::layers();
     # Some models or softwware versions don't report L2 properly
     # so add L2 capability to the output if the device has bridge ports.
     my $bports = $pfront->b_ports();
-    
+
     if ($bports) {
         my $l = substr $layers, 6, 1, "1";
     }
@@ -137,14 +137,14 @@ initial version based on SNMP::Info::Layer3::NetSNMP by Bradley Baetz and Bill F
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $pfront = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $pfront->class();
@@ -202,7 +202,7 @@ Returns the software version extracted from C<sysDescr>.
 
 =item $pfront->serial()
 
-Returns the value of C<productSerialNo>. 
+Returns the value of C<productSerialNo>.
 
 =back
 
@@ -227,7 +227,7 @@ Ignores loopback
 
 =item $pfront->layers()
 
-L2 capability isn't always reported correctly by the device itself; what the 
+L2 capability isn't always reported correctly by the device itself; what the
 device reports is augmented with L2 capability if the device has bridge ports.
 
 =back

--- a/lib/SNMP/Info/Layer3/Passport.pm
+++ b/lib/SNMP/Info/Layer3/Passport.pm
@@ -676,7 +676,7 @@ sub fw_status {
 
     my $qb = $passport->SUPER::fw_status($partial);
     return $qb if (ref {} eq ref $qb and scalar keys %$qb);
-    
+
     return $passport->rcBridgeTpFdbStatus($partial);
 }
 
@@ -1179,14 +1179,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $passport = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $passport->class();
@@ -1197,12 +1197,12 @@ Eric Miller
 Abstraction subclass for modular Avaya Ethernet Routing Switch 8000 Series
 (formerly Nortel/Bay Passport/Accelar) and VSP 9000 Series switches.
 
-These devices have some of the same characteristics as the stackable Avaya 
-Ethernet Switches (Baystack).  For example, extended interface information is 
+These devices have some of the same characteristics as the stackable Avaya
+Ethernet Switches (Baystack).  For example, extended interface information is
 gleaned from F<RAPID-CITY>.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $passport = new SNMP::Info::Layer3::Passport(...);
 
@@ -1240,7 +1240,7 @@ These are methods that return scalar value from SNMP
 
 =item $passport->model()
 
-Returns model type.  Checks $passport->id() against the 
+Returns model type.  Checks $passport->id() against the
 F<RAPID-CITY-MIB> and then parses out C<rcA>.
 
 =item $passport->vendor()
@@ -1364,7 +1364,7 @@ problems with F<BRIDGE-MIB>
 These methods utilize, in order; F<Q-BRIDGE-MIB>, F<BRIDGE-MIB>, and
 F<RAPID-CITY> to obtain the forwarding table information.
 
-=over 
+=over
 
 =item $passport->fw_mac()
 

--- a/lib/SNMP/Info/Layer3/Pf.pm
+++ b/lib/SNMP/Info/Layer3/Pf.pm
@@ -132,7 +132,7 @@ Max Baker
 =head1 SYNOPSIS
 
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $pf = new SNMP::Info(
                         AutoSpecify => 1,
                         Debug       => 1,
@@ -140,7 +140,7 @@ Max Baker
                         DestHost    => 'myswitch',
                         Community   => 'public',
                         Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $pf->class();
@@ -157,7 +157,7 @@ that the available CDP/LLDP modules for net-snmp don't work on FreeBSD (on
 which pfSense is based) as they assume certain Linux specific Ethernet
 structures.  This problem is apparently solved on PF based firewall appliances
 by using the ladvd package, for which a port may be found here:
-L<http://www.freshports.org/net/ladvd/>.  I'm not sure if this module ties into 
+L<http://www.freshports.org/net/ladvd/>.  I'm not sure if this module ties into
 Net-SNMP or not.
 
 =head2 Inherited Classes
@@ -205,7 +205,7 @@ Returns 'Pf'
 =item $pf->os_ver()
 
 Tries to reference $pf->id() to one of the product MIBs listed above.
-Will probably return a truncation of the default OID for pf-based systems 
+Will probably return a truncation of the default OID for pf-based systems
 C<enterprises.12325.1.1.2.1.1>.
 
 =back

--- a/lib/SNMP/Info/Layer3/Pica8.pm
+++ b/lib/SNMP/Info/Layer3/Pica8.pm
@@ -102,14 +102,14 @@ Jeroen van Ingen
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $pica8 = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $pica8->class();

--- a/lib/SNMP/Info/Layer3/SonicWALL.pm
+++ b/lib/SNMP/Info/Layer3/SonicWALL.pm
@@ -175,12 +175,6 @@ See documentation in L<SNMP::Info::Layer3/"GLOBALS"> for details.
 These are methods that return tables of information in the form of a reference
 to a hash.
 
-=head2 Overrides
-
-=over
-
-=back
-
 =head2 Table Methods imported from SNMP::Info::Layer3
 
 See documentation in L<SNMP::Info::Layer3/"TABLE METHODS"> for details.

--- a/lib/SNMP/Info/Layer3/Steelhead.pm
+++ b/lib/SNMP/Info/Layer3/Steelhead.pm
@@ -72,7 +72,7 @@ sub model {
     my $riverbed = shift;
 
     my $model = $riverbed->rb_model() || '';
-    
+
     if ($model =~ /^(\d+)/) {
         return $1;
     }
@@ -85,19 +85,19 @@ sub os {
 
 sub os_ver {
     my $riverbed = shift;
-    
+
     my $ver = $riverbed->systemVersion() || '';
 
     if ( $ver =~ /(\d+[\.\d]+)/ ) {
         return $1;
     }
-    
+
     return $ver;
 }
 
 sub serial {
     my $riverbed = shift;
-    
+
     return $riverbed->serialNumber();
 }
 
@@ -115,14 +115,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $riverbed = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $riverbed->class();
@@ -133,7 +133,7 @@ Eric Miller
 Abstraction subclass for Riverbed Steelhead WAN optimization appliances.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $riverbed = new SNMP::Info::Layer3::Steelhead(...);
 

--- a/lib/SNMP/Info/Layer3/Sun.pm
+++ b/lib/SNMP/Info/Layer3/Sun.pm
@@ -113,14 +113,14 @@ begemot
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $sun = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'mysunrouter',
                           Community   => 'public',
                           Version     => 1
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $sun->class();

--- a/lib/SNMP/Info/Layer3/Tasman.pm
+++ b/lib/SNMP/Info/Layer3/Tasman.pm
@@ -340,7 +340,7 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $tasman = new SNMP::Info(
                         AutoSpecify => 1,
                         Debug       => 1,
@@ -348,7 +348,7 @@ Eric Miller
                         DestHost    => 'myswitch',
                         Community   => 'public',
                         Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $tasman->class();
@@ -400,7 +400,7 @@ Returns C<'avaya'>
 
 =item $tasman->model()
 
-Tries to get the model from C<nnchassisModel> and if not available 
+Tries to get the model from C<nnchassisModel> and if not available
 cross references $tasman->id() to F<NT-ENTERPRISE-DATA-MIB>.
 
 Substitutes 'SR' for C<'ntSecureRouter'> in the name for readability.
@@ -487,7 +487,7 @@ C<portAdminSpeed>
 =head2 Pseudo F<ENTITY-MIB> information
 
 These methods emulate F<ENTITY-MIB> Physical Table methods using
-F<CHASSIS-MIB>. 
+F<CHASSIS-MIB>.
 
 =over
 

--- a/lib/SNMP/Info/Layer3/Timetra.pm
+++ b/lib/SNMP/Info/Layer3/Timetra.pm
@@ -275,7 +275,7 @@ sub i_duplex_admin {
 
 sub agg_ports {
     my $alu = shift;
-    
+
     return $alu->agg_ports_ifstack();
 }
 
@@ -402,7 +402,7 @@ Bill Fenner
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $alu = new SNMP::Info(
                         AutoSpecify => 1,
                         Debug       => 1,
@@ -410,7 +410,7 @@ Bill Fenner
                         DestHost    => 'myswitch',
                         Community   => 'public',
                         Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $alu->class();
@@ -527,7 +527,7 @@ upon the transceiver inserted.
 
 =item $alu->lldp_if()
 
-Returns the mapping to the SNMP Interface Table. Utilizes (C<ifIndex>) 
+Returns the mapping to the SNMP Interface Table. Utilizes (C<ifIndex>)
 from the (C<tmnxLldpRemEntry >) index.
 
 =back

--- a/lib/SNMP/Info/Layer3/VyOS.pm
+++ b/lib/SNMP/Info/Layer3/VyOS.pm
@@ -43,12 +43,10 @@ $VERSION = '3.64';
 
 %MIBS = (
     %SNMP::Info::Layer2::MIBS, %SNMP::Info::Layer3::MIBS,
-    
 );
 
 %GLOBALS = (
     %SNMP::Info::Layer2::GLOBALS, %SNMP::Info::Layer3::GLOBALS,
-    
 );
 
 %FUNCS = ( %SNMP::Info::Layer2::FUNCS, %SNMP::Info::Layer3::FUNCS, );
@@ -106,14 +104,14 @@ SNMP::Info::Layer3::VyOS - SNMP Interface to Vyatta Devices
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $vyos = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $vyos->class();

--- a/lib/SNMP/Info/Layer7.pm
+++ b/lib/SNMP/Info/Layer7.pm
@@ -66,7 +66,7 @@ sub model {
     my $id    = $l7->id();
     my $model = &SNMP::translateObj($id);
 
-    # Neoteris (Juniper IVE)    
+    # Neoteris (Juniper IVE)
     $model =~ s/^ive//i;
 
     return $model;
@@ -113,14 +113,14 @@ Jeroen van Ingen
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $l7 = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 1
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $l7->class();
@@ -144,15 +144,15 @@ This class is usually used as a superclass for more specific device classes
 listed under SNMP::Info::Layer7::*   Please read all docs under SNMP::Info
 first.
 
-Provides abstraction to the configuration information obtainable from a 
+Provides abstraction to the configuration information obtainable from a
 Layer7 device through SNMP.  Information is stored in a number of MIBs.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $l7 = new SNMP::Info::Layer7(...);
 
-=head2 Inherited Classes 
+=head2 Inherited Classes
 
 =over
 
@@ -160,7 +160,7 @@ after determining a more specific class using the method above.
 
 =back
 
-=head2 Required MIBs 
+=head2 Required MIBs
 
 =over
 

--- a/lib/SNMP/Info/Layer7.pm
+++ b/lib/SNMP/Info/Layer7.pm
@@ -176,10 +176,6 @@ See L<SNMP::Info/"Required MIBs"> for its MIB requirements.
 
 These are methods that return scalar value from SNMP
 
-=over
-
-=back
-
 =head2 Overrides
 
 =over

--- a/lib/SNMP/Info/Layer7/APC.pm
+++ b/lib/SNMP/Info/Layer7/APC.pm
@@ -63,7 +63,7 @@ $VERSION = '3.64';
 
 %FUNCS = (
     %SNMP::Info::Layer7::FUNCS,
-    
+
 );
 
 %MUNGE = (
@@ -115,14 +115,14 @@ Jeroen van Ingen
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $apc = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $apc->class();
@@ -130,11 +130,11 @@ Jeroen van Ingen
 
 =head1 DESCRIPTION
 
-Provides abstraction to the configuration information obtainable from a 
-APC UPS via SNMP. 
+Provides abstraction to the configuration information obtainable from a
+APC UPS via SNMP.
 
 For speed or debugging purposes you can call the subclass directly, but not
-after determining a more specific class using the method above. 
+after determining a more specific class using the method above.
 
  my $apc = new SNMP::Info::Layer7::APC(...);
 
@@ -235,6 +235,6 @@ See documentation in L<SNMP::Info::Layer7/"TABLE METHODS"> for details.
 These are methods that provide SNMP set functionality for overridden methods
 or provide a simpler interface to complex set operations.  See
 L<SNMP::Info/"SETTING DATA VIA SNMP"> for general information on set
-operations. 
+operations.
 
 =cut

--- a/lib/SNMP/Info/Layer7/APC.pm
+++ b/lib/SNMP/Info/Layer7/APC.pm
@@ -214,21 +214,9 @@ See documentation in L<SNMP::Info::Layer7/"GLOBALS"> for details.
 These are methods that return tables of information in the form of a reference
 to a hash.
 
-=head2 Overrides
-
-=over
-
-=back
-
 =head2 Table Methods imported from SNMP::Info::Layer7
 
 See documentation in L<SNMP::Info::Layer7/"TABLE METHODS"> for details.
-
-=head1 MUNGES
-
-=over
-
-=back
 
 =head1 SET METHODS
 

--- a/lib/SNMP/Info/Layer7/CiscoIPS.pm
+++ b/lib/SNMP/Info/Layer7/CiscoIPS.pm
@@ -68,10 +68,10 @@ my ($serial, $descr, $model);
 sub _fetch_info {
     my $self = shift;
     foreach my $id ( keys %{ $self->e_id() } ){
-        
+
         if (
             $self->e_name->{$id} =~ m/^Module$/ and
-            $self->e_model->{$id} =~ m/IPS/ 
+            $self->e_model->{$id} =~ m/IPS/
         ) {
             $serial = $self->e_serial->{$id};
             $descr  = $self->e_descr->{$id};
@@ -79,7 +79,7 @@ sub _fetch_info {
         }
 
     }
-    
+
 }
 
 sub layers {
@@ -113,14 +113,14 @@ sub productname {
 
 sub b_mac {
     my ( $self ) = shift;
-    
+
     foreach my $mac ( values %{$self->i_mac()} ){
 
         next unless defined $mac;
         next unless $mac =~ m/^e4:d3:f1/;
         return  $mac;
     }
-    
+
     return '';
 }
 
@@ -162,7 +162,7 @@ Moe Kraus
 
 =head1 DESCRIPTION
 
-Subclass for Cisco IPS Module 
+Subclass for Cisco IPS Module
 
 =head2 Inherited Classes
 

--- a/lib/SNMP/Info/Layer7/Gigamon.pm
+++ b/lib/SNMP/Info/Layer7/Gigamon.pm
@@ -87,14 +87,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $g = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $g->class();

--- a/lib/SNMP/Info/Layer7/Liebert.pm
+++ b/lib/SNMP/Info/Layer7/Liebert.pm
@@ -84,14 +84,14 @@ Netdisco Developers
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $liebert = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myhub',
                           Community   => 'public',
                           Version     => 1
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $liebert->class();

--- a/lib/SNMP/Info/Layer7/Neoteris.pm
+++ b/lib/SNMP/Info/Layer7/Neoteris.pm
@@ -81,14 +81,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $neoteris = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $neoteris->class();

--- a/lib/SNMP/Info/Layer7/Netscaler.pm
+++ b/lib/SNMP/Info/Layer7/Netscaler.pm
@@ -80,7 +80,7 @@ sub serial {
 sub model {
     my $ns    = shift;
     my $desc  = $ns->sys_hw_desc() || '';
-   
+
     $desc =~ s/^.+\bNS//i;
 
     return $desc;
@@ -121,14 +121,14 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $ns = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myrouter',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $ns->class();

--- a/lib/SNMP/Info/MAU.pm
+++ b/lib/SNMP/Info/MAU.pm
@@ -460,10 +460,10 @@ Max Baker
 
 =head1 SYNOPSIS
 
- my $mau = new SNMP::Info ( 
+ my $mau = new SNMP::Info (
                              AutoSpecify => 1,
                              Debug       => 1,
-                             DestHost    => 'hpswitch', 
+                             DestHost    => 'hpswitch',
                              Community   => 'public',
                              Version     => 2
                            );
@@ -551,14 +551,14 @@ and their index in the MAU IF Table.
 
 (C<ifMauIfIndex>)
 
-=item $mau->mau_link() - Returns the type of Media Access used.  
+=item $mau->mau_link() - Returns the type of Media Access used.
 
-    This is essentially the type of link in use.  
+    This is essentially the type of link in use.
     eg. dot3MauType100BaseTXFD - 100BaseT at Full Duplex
 
 (C<ifMauType>)
 
-=item $mau->mau_status() - Returns the admin link condition as 
+=item $mau->mau_status() - Returns the admin link condition as
 
     1 - other
     2 - unknown
@@ -576,9 +576,9 @@ Use 5 and !5 to see if the link is up or down on the admin side.
  (C<ifMauMediaAvailable>)
 
 =item $mau->mau_type() - Returns a 32bit string reporting the capabilities
-of the port from a MAU POV. 
+of the port from a MAU POV.
 
-  Directly from F<MAU-MIB> : 
+  Directly from F<MAU-MIB> :
           Bit   Capability
             0      other or unknown
             1      AUI
@@ -619,14 +619,14 @@ ports.
 (C<ifMauAutoNegAdminStatus>)
 
 =item $mau->mau_autosent() - Returns a 32 bit bit-string representing the
-capabilities we are broadcasting on that port 
+capabilities we are broadcasting on that port
 
     Uses the same decoder as $mau->mau_type().
 
 (C<ifMauAutoNegCapAdvertised>)
 
-=item $mau->mau_autorec() - Returns a 32 bit bit-string representing the 
-capabilities of the device on the other end. 
+=item $mau->mau_autorec() - Returns a 32 bit bit-string representing the
+capabilities of the device on the other end.
 
     Uses the same decoder as $mau->mau_type().
 
@@ -641,7 +641,7 @@ or provide a simpler interface to complex set operations.  See
 L<SNMP::Info/"SETTING DATA VIA SNMP"> for general information on set
 operations.
 
-=over 
+=over
 
 =item $mau->mau_set_i_speed_admin(speed, ifIndex)
 
@@ -684,7 +684,7 @@ Accepts the following values for speed and duplex:
 
 =head1 Utility Functions
 
-=over 
+=over
 
 =item munge_int2bin() - Unpacks an integer into a 32bit bit string.
 

--- a/lib/SNMP/Info/MAU.pm
+++ b/lib/SNMP/Info/MAU.pm
@@ -467,7 +467,7 @@ Max Baker
                              Community   => 'public',
                              Version     => 2
                            );
- 
+
  my $class = $mau->class();
  print " Using device sub class : $class\n";
 

--- a/lib/SNMP/Info/MRO.pm
+++ b/lib/SNMP/Info/MRO.pm
@@ -5,7 +5,7 @@ use strict;
 
 use vars qw/$VERSION/;
 $VERSION = '3.64';
- 
+
 use PPI;
 use Class::ISA;  ## no critic
 use Module::Info;
@@ -67,7 +67,7 @@ sub _walk_global_data {
 
 sub _print_global_data {
     my $results = _walk_global_data(@_);
-    
+
     foreach my $key (sort keys %$results) {
         print $key, "\n";
         my @defs = @{ $results->{$key} };
@@ -96,7 +96,7 @@ SNMP::Info::MRO - Method resolution introspection for SNMP::Info
 
  use SNMP::Info::MRO;
  use Data::Printer;
- 
+
  p SNMP::Info::MRO::all_methods('SNMP::Info::Layer3::Juniper');
 
 =head1 DESCRIPTION

--- a/lib/SNMP/Info/MRO.pm
+++ b/lib/SNMP/Info/MRO.pm
@@ -157,7 +157,7 @@ or C<%FUNCS> configuration. The data structure looks like:
  }
 
 It should be noted that the order of method resolution in SNMP::Info is to
-first look for a defined subroutine (this is done by Perl), then the 
+first look for a defined subroutine (this is done by Perl), then the
 AUTOLOAD sequence will search for a definition in C<%GLOBALS> followed by
 C<%FUNCS>.
 

--- a/lib/SNMP/Info/NortelStack.pm
+++ b/lib/SNMP/Info/NortelStack.pm
@@ -558,7 +558,7 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $stack = new SNMP::Info(
                     AutoSpecify => 1,
                     Debug       => 1,
@@ -566,7 +566,7 @@ Eric Miller
                     DestHost    => 'myswitch',
                     Community   => 'public',
                     Version     => 2
-                    ) 
+                    )
     or die "Can't connect to DestHost.\n";
 
  my $class = $stack->class();
@@ -620,13 +620,13 @@ Returns serial number of the chassis
 =item $stack->ns_ag_ver()
 
 Returns the version of the agent in the form
-'major.minor.maintenance[letters]'. 
+'major.minor.maintenance[letters]'.
 
 (C<s5AgInfoVer>)
 
 =item $stack->ns_op_mode()
 
-Returns the stacking mode. 
+Returns the stacking mode.
 
 (C<s5AgSysCurrentOperationalMode>)
 
@@ -821,7 +821,7 @@ Returns reference to hash.  Key: Table entry, Value: Version
 =head2 Pseudo F<ENTITY-MIB> information
 
 These methods emulate F<ENTITY-MIB> Physical Table methods using
-F<S5-CHASSIS-MIB>. 
+F<S5-CHASSIS-MIB>.
 
 =over
 
@@ -905,7 +905,7 @@ is not contained in any other entity.
 
 =item $stack->munge_ns_grp_type()
 
-Munges C<s5ChasGrpType> into an C<ENTITY-MIB PhysicalClass> equivalent. 
+Munges C<s5ChasGrpType> into an C<ENTITY-MIB PhysicalClass> equivalent.
 
 =back
 

--- a/lib/SNMP/Info/PowerEthernet.pm
+++ b/lib/SNMP/Info/PowerEthernet.pm
@@ -126,14 +126,14 @@ Bill Fenner
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $poe = new SNMP::Info(
                           AutoSpecify => 1,
                           Debug       => 1,
                           DestHost    => 'myswitch',
                           Community   => 'public',
                           Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class      = $poe->class();

--- a/lib/SNMP/Info/RapidCity.pm
+++ b/lib/SNMP/Info/RapidCity.pm
@@ -154,7 +154,7 @@ $VERSION = '3.64';
     'rc2k_mda_part'   => 'rc2kMdaCardPartNumber',
     'rc2k_mda_date'   => 'rc2kMdaCardDateCode',
     'rc2k_mda_dev'    => 'rc2kMdaCardDeviations',
-    
+
     # From RAPID-CITY::rcMltTable
     'rc_mlt_ports'    => 'rcMltPortMembers',
     'rc_mlt_index'    => 'rcMltIfIndex',
@@ -396,13 +396,13 @@ sub i_vlan_membership_untagged {
             if ($p_tag_opt->{$port}) {
                 if ($p_tag_opt->{$port} eq 'untagPvidOnly') {
                     my $vlan = $i_vlan->{$port};
-                    push( @{ $members_untagged->{$port} }, $vlan );                    
+                    push( @{ $members_untagged->{$port} }, $vlan );
                 }
                 elsif (($p_tag_opt->{$port} eq 'true') and
                        ($p_untag_def->{$port} and $p_untag_def->{$port} eq 'true'))
                 {
                     my $vlan = $i_vlan->{$port};
-                    push( @{ $members_untagged->{$port} }, $vlan );                     
+                    push( @{ $members_untagged->{$port} }, $vlan );
                 }
                 elsif ($p_tag_opt->{$port} eq 'tagPvidOnly') {
                     my $vlan = $i_vlan->{$port};
@@ -424,7 +424,7 @@ sub i_vlan_membership_untagged {
             }
         }
     }
- 
+
     return $members_untagged;
 }
 
@@ -883,7 +883,7 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- # Let SNMP::Info determine the correct subclass for you. 
+ # Let SNMP::Info determine the correct subclass for you.
  my $rapidcity = new SNMP::Info(
                         AutoSpecify => 1,
                         Debug       => 1,
@@ -891,7 +891,7 @@ Eric Miller
                         DestHost    => 'myswitch',
                         Community   => 'public',
                         Version     => 2
-                        ) 
+                        )
     or die "Can't connect to DestHost.\n";
 
  my $class = $rapidcity->class();
@@ -980,7 +980,7 @@ Returns serial number of the chassis
 
 =item $rapidcity->stp_ver()
 
-Returns the particular STP version running on this device.  
+Returns the particular STP version running on this device.
 
 Values: C<nortelStpg>, C<pvst>, C<rstp>, C<mstp>, C<ieee8021d>
 
@@ -1015,7 +1015,7 @@ IDs.  These are the VLANs which are members of the egress list for the port.
   Example:
   my $interfaces = $rapidcity->interfaces();
   my $vlans      = $rapidcity->i_vlan_membership();
-  
+
   foreach my $iid (sort keys %$interfaces) {
     my $port = $interfaces->{$iid};
     my $vlan = join(',', sort(@{$vlans->{$iid}}));
@@ -1486,7 +1486,7 @@ of the Port ID is given by the value of C<dot1dStpPort>."
 =item $rapidcity->stp_p_state()
 
 "The port's current state as defined by application of the Spanning Tree
-Protocol."  
+Protocol."
 
 =item $rapidcity->stp_p_cost()
 
@@ -1516,7 +1516,7 @@ segment."
 These are methods that provide SNMP set functionality for overridden methods
 or provide a simpler interface to complex set operations.  See
 L<SNMP::Info/"SETTING DATA VIA SNMP"> for general information on set
-operations. 
+operations.
 
 =over
 
@@ -1527,7 +1527,7 @@ choices are 'auto', '10', '100', '1000'.
 
  Example:
  my %if_map = reverse %{$rapidcity->interfaces()};
- $rapidcity->set_i_speed_admin('auto', $if_map{'1.1'}) 
+ $rapidcity->set_i_speed_admin('auto', $if_map{'1.1'})
     or die "Couldn't change port speed. ",$rapidcity->error(1);
 
 =item $rapidcity->set_i_duplex_admin(duplex, ifIndex)
@@ -1537,7 +1537,7 @@ choices are 'auto', 'half', 'full'.
 
   Example:
   my %if_map = reverse %{$rapidcity->interfaces()};
-  $rapidcity->set_i_duplex_admin('auto', $if_map{'1.1'}) 
+  $rapidcity->set_i_duplex_admin('auto', $if_map{'1.1'})
     or die "Couldn't change port duplex. ",$rapidcity->error(1);
 
 =item $rapidcity->set_i_vlan(vlan, ifIndex)
@@ -1549,7 +1549,7 @@ station (non-trunk) ports.
 
   Example:
   my %if_map = reverse %{$rapidcity->interfaces()};
-  $rapidcity->set_i_vlan('2', $if_map{'1.1'}) 
+  $rapidcity->set_i_vlan('2', $if_map{'1.1'})
     or die "Couldn't change port VLAN. ",$rapidcity->error(1);
 
 =item $rapidcity->set_i_pvid(pvid, ifIndex)
@@ -1560,7 +1560,7 @@ port C<ifIndex>.  This method only changes the PVID, to modify an access
 
   Example:
   my %if_map = reverse %{$rapidcity->interfaces()};
-  $rapidcity->set_i_pvid('2', $if_map{'1.1'}) 
+  $rapidcity->set_i_pvid('2', $if_map{'1.1'})
     or die "Couldn't change port PVID. ",$rapidcity->error(1);
 
 =item $rapidcity->set_add_i_vlan_tagged(vlan, ifIndex)
@@ -1570,7 +1570,7 @@ numeric VLAN ID and port C<ifIndex>.
 
   Example:
   my %if_map = reverse %{$rapidcity->interfaces()};
-  $rapidcity->set_add_i_vlan_tagged('2', $if_map{'1.1'}) 
+  $rapidcity->set_add_i_vlan_tagged('2', $if_map{'1.1'})
     or die "Couldn't add port to egress list. ",$rapidcity->error(1);
 
 =item $rapidcity->set_remove_i_vlan_tagged(vlan, ifIndex)
@@ -1580,7 +1580,7 @@ numeric VLAN ID and port C<ifIndex>.
 
   Example:
   my %if_map = reverse %{$rapidcity->interfaces()};
-  $rapidcity->set_remove_i_vlan_tagged('2', $if_map{'1.1'}) 
+  $rapidcity->set_remove_i_vlan_tagged('2', $if_map{'1.1'})
     or die "Couldn't add port to egress list. ",$rapidcity->error(1);
 
 =item $rapidcity->set_delete_vlan(vlan)
@@ -1592,7 +1592,7 @@ Deletes the specified VLAN from the device.
 Creates the specified VLAN on the device.
 
 Note:  This method only allows creation of Port type VLANs and does not allow
-for the setting of the Spanning Tree Group (STG) which defaults to 1.   
+for the setting of the Spanning Tree Group (STG) which defaults to 1.
 
 =back
 

--- a/lib/SNMP/Info/SONMP.pm
+++ b/lib/SNMP/Info/SONMP.pm
@@ -147,7 +147,7 @@ sub sonmp_if {
                 $port = 26;
             }
         }
-        
+
         my $index;
         my $int = $sub_port ? "$slot.$port.$sub_port" : "$slot.$port";
 
@@ -292,10 +292,10 @@ Eric Miller
 
 =head1 SYNOPSIS
 
- my $sonmp = new SNMP::Info ( 
+ my $sonmp = new SNMP::Info (
                              AutoSpecify => 1,
                              Debug       => 1,
-                             DestHost    => 'router', 
+                             DestHost    => 'router',
                              Community   => 'public',
                              Version     => 2
                            );
@@ -321,7 +321,7 @@ Eric Miller
 
 =head1 DESCRIPTION
 
-SNMP::Info::SONMP is a subclass of SNMP::Info that provides an object oriented 
+SNMP::Info::SONMP is a subclass of SNMP::Info that provides an object oriented
 interface to the SynOptics Network Management Protocol (SONMP) information
 through SNMP.
 
@@ -334,7 +334,7 @@ Discovery Protocol (NDP).
 Create or use a device subclass that inherits this class.  Do not use
 directly.
 
-Each device implements a subset of the global and cache entries. 
+Each device implements a subset of the global and cache entries.
 Check the return value to see if that data is held by the device.
 
 =head2 Inherited Classes
@@ -368,7 +368,7 @@ Returns the offset if slot numbering does not start at 0.  Defaults to 1.
 
 =item $sonmp->port_offset()
 
-Returns the offset if port numbering does not start at 0.  Defaults to 0. 
+Returns the offset if port numbering does not start at 0.  Defaults to 0.
 
 =item  $sonmp->hasSONMP()
 
@@ -382,13 +382,13 @@ Returns the IP that the device is sending out for its Nmm topology info.
 
 =item $sonmp->sonmp_run()
 
-Returns true if SONMP is on for this device. 
+Returns true if SONMP is on for this device.
 
 (C<s5EnMsTopStatus>)
 
 =item $sonmp->mac()
 
-Returns MAC of the advertised IP address of this device. 
+Returns MAC of the advertised IP address of this device.
 
 =back
 
@@ -481,7 +481,7 @@ Returns reference to hash.  Key: IID, Value: Remote IP address
 
 If multiple entries exist with the same local port, sonmp_if(), with different
 IPv4 addresses, sonmp_ip(), there is either a non SONMP device in between two or
-more devices or multiple devices which are not directly connected.  
+more devices or multiple devices which are not directly connected.
 
 Use the data from the Layer2 Topology Table below to dig deeper.
 

--- a/t/00_load.t
+++ b/t/00_load.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# 00-load.t - Test loading of SNMP::Info 
+# 00-load.t - Test loading of SNMP::Info
 # $Id$
 
 use strict;

--- a/xt/00_local_docininfo.t
+++ b/xt/00_local_docininfo.t
@@ -35,7 +35,7 @@ sub check_version {
 
     # Make sure that this package is listed in Info.pm
     fail($_) unless $content =~ m/^\s*package\s+(\S+)\s*;/m;
-    
+
     my $package = $1;
 
     return if $package eq 'SNMP::Info';

--- a/xt/00_local_prereq.t
+++ b/xt/00_local_prereq.t
@@ -20,12 +20,12 @@ Net-SNMP not found.  Net-SNMP installs the perl modules SNMP and
 SNMP::Session.
 
 Versions 4.2.1 to 5.3 the Perl modules are not distributed on CPAN, you must
-install from the distribution. 
+install from the distribution.
 
 Install Net-SNMP from http://net-snmp.sourceforge.net and make sure you run
 configure with the --with-perl-modules switch!
 
-Note to Redhat Users:  Redhat, in its infinite wisdom, does not install the 
+Note to Redhat Users:  Redhat, in its infinite wisdom, does not install the
 Perl modules as part of their 8.0 RPMS.  Please uninstall them and install the
 newest version by hand.
 
@@ -48,20 +48,20 @@ SKIP: {
     my ($ver_maj,$ver_min,$ver_rev) = split(/\./,$VERSION);
 
     ok ($ver_maj >= 4, 'Net-SNMP ver 4 or higher');
-    
+
     if ($ver_maj == 4 and $ver_min == 2 and $ver_rev == 0){
         print STDERR << "end_420";
 
 SNMP module version 4.2.0 found.  Please triple check that you have
 version 4.2.0 of Net-SNMP installed, and that you did not accidently install
-the SNMP module found on CPAN.  All newer versions are bundled with 
-Net-SNMP, and are not available on CPAN.  Please find them at 
-http://net-snmp.sourceforge.net .  Make sure you run configure with the 
+the SNMP module found on CPAN.  All newer versions are bundled with
+Net-SNMP, and are not available on CPAN.  Please find them at
+http://net-snmp.sourceforge.net .  Make sure you run configure with the
 --with-perl-modules switch.
 
 end_420
     }
- 
+
     if( $ver_maj == 5 and $ver_min == 0 and $ver_rev == 1 ){
         print STDERR << "end_501";
 
@@ -71,7 +71,7 @@ Perl module of Net-SNMP 5.0.1 is buggy. Please upgrade.
 
 end_501
     }
- 
+
     if(( $ver_maj == 5 and $ver_min == 3 and $ver_rev == 1 ) or
       ( $ver_maj == 5 and $ver_min == 2 and $ver_rev == 3 )) {
         print STDERR << "end_bulkwalk";
@@ -81,13 +81,13 @@ Perl module of Net-SNMP Versions 5.3.1 and 5.2.3 have issues with bulkwalk,
 turn off bulkwalk. Please upgrade.
 
 end_bulkwalk
-    } 
+    }
 }
 
 print STDERR << "end_mibs";
 
 
-Make sure you download and install the MIBS needed for SNMP::Info.   
+Make sure you download and install the MIBS needed for SNMP::Info.
 See Man page or perldoc for SNMP::Info.
 
 end_mibs

--- a/xt/lib/Test/SNMP/Info.pm
+++ b/xt/lib/Test/SNMP/Info.pm
@@ -463,7 +463,7 @@ sub ip_index : Tests(4) {
   can_ok($test->{info}, 'ip_index');
 
   my $cache_data = {
-    '_old_ip_index' => 1,    
+    '_old_ip_index' => 1,
     '_new_ip_index' => 1,
     '_new_ip_type'  => 1,
     'store'        => {
@@ -498,7 +498,7 @@ sub ip_table : Tests(4) {
   can_ok($test->{info}, 'ip_table');
 
   my $cache_data = {
-    '_old_ip_table' => 1,    
+    '_old_ip_table' => 1,
     '_new_ip_index' => 1,
     '_new_ip_type'  => 1,
     'store'        => {
@@ -533,7 +533,7 @@ sub ip_netmask : Tests(4) {
   can_ok($test->{info}, 'ip_netmask');
 
   my $cache_data = {
-    '_old_ip_netmask' => 1,    
+    '_old_ip_netmask' => 1,
     '_new_ip_prefix' => 1,
     '_new_ip_type'  => 1,
     'store'        => {
@@ -908,7 +908,7 @@ sub resolve_desthost : Tests(6) {
     'udp6:fe80:0:0:0:2d0:b7ff:fe21:c6c0',
     q(Net-SNMP example IPv6 address returns with 'udp6:' prefix)
   );
-  
+
   dies_ok { SNMP::Info::resolve_desthost('1.2.3.4.5') } 'Bad IP dies';
 }
 

--- a/xt/lib/Test/SNMP/Info/Bridge.pm
+++ b/xt/lib/Test/SNMP/Info/Bridge.pm
@@ -60,7 +60,7 @@ sub qb_fdb_index : Tests(3) {
     my $test = shift;
 
     can_ok( $test->{info}, 'qb_fdb_index' );
-    
+
     my $expected = { 0 => 1, 3 => 91, 1 => 112, 2 => 113 };
     cmp_deeply( $test->{info}->qb_fdb_index(), $expected, q(FDB to VLAN index returned expected values));
 

--- a/xt/lib/Test/SNMP/Info/LLDP.pm
+++ b/xt/lib/Test/SNMP/Info/LLDP.pm
@@ -377,9 +377,9 @@ sub lldp_cap : Tests(4) {
   can_ok($test->{info}, 'lldp_cap');
 
   my $expected = ['bridge', 'router'];
-  
+
   my $caps = $test->{info}->lldp_cap();
- 
+
   cmp_set($caps->{'0.6.1'}, $expected,
     q(Caps emumerated correctly));
 

--- a/xt/lib/Test/SNMP/Info/Layer2/Aironet.pm
+++ b/xt/lib/Test/SNMP/Info/Layer2/Aironet.pm
@@ -74,7 +74,7 @@ sub setup : Tests(setup) {
         2 => '802.11G Radio',
         3 => '802.11A Radio',
         4 => 'PowerPCElvis Ethernet',
-      },     
+      },
 
     },
   };

--- a/xt/lib/Test/SNMP/Info/Layer2/Sixnet.pm
+++ b/xt/lib/Test/SNMP/Info/Layer2/Sixnet.pm
@@ -78,7 +78,7 @@ sub model : Tests(5) {
   $test->{info}{_id} = '.100.3.6.1.4.1.20540.2.1';
   is($test->{info}->model(), '.100.3.6.1.4.1.20540.2.1',
      q(Model is expected value when id doesn't translate));
-  
+
   $test->{info}->clear_cache();
   is($test->{info}->model(), undef, q(No data returns undef model));
 }

--- a/xt/lib/Test/SNMP/Info/Layer3/Arista.pm
+++ b/xt/lib/Test/SNMP/Info/Layer3/Arista.pm
@@ -44,7 +44,7 @@ sub startup : Tests(startup => 1) {
 sub setup : Tests(setup) {
   my $test = shift;
   $test->SUPER::setup;
-  
+
   # Start with a common cache that will serve most tests
   my $d_string = 'Arista Networks EOS version 4.10.4 ';
   $d_string .= 'running on an Arista Networks DCS-7048T-A';

--- a/xt/lib/Test/SNMP/Info/PowerEthernet.pm
+++ b/xt/lib/Test/SNMP/Info/PowerEthernet.pm
@@ -43,7 +43,7 @@ sub setup : Tests(setup) {
     '_peth_port_class'  => 1,
     'store' => {
       'peth_port_status' => {'1.1' => 'searching', '1.3' => 'otherFault', '1.24' => 'deliveringPower'},
-      'peth_port_class'  => {'1.1' => 'class0', '1.3' => 'class0', '1.24' => 'class3'},      
+      'peth_port_class'  => {'1.1' => 'class0', '1.3' => 'class0', '1.24' => 'class3'},
       },
   };
   $test->{info}->cache($cache_data);


### PR DESCRIPTION
also clean up a few pod errors, remove a few empty paragraphs from manuals & fix up ciscostpextensions manual.