### PR TITLE
Update VyOS Official enterprise OID

### DIFF
--- a/lib/SNMP/Info.pm
+++ b/lib/SNMP/Info.pm
@@ -1675,6 +1675,7 @@ sub device_type {
         4413 => 'SNMP::Info::Layer2::Ubiquiti',
         26928 => 'SNMP::Info::Layer2::Aerohive',
         30803 => 'SNMP::Info::Layer3::VyOS',
+	44641 => 'SNMP::Info::Layer3::VyOS',
         40310 => 'SNMP::Info::Layer3::Cumulus',
     );
 


### PR DESCRIPTION
VyOS project has their own OID as of the release of 1.2.0: https://wiki.vyos.net/wiki/1.2.0/release_notes#SNMP_sysDescr_and_OID