### PR TITLE
make fortinet return a useful interface name.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+Version 3.67 (2019-xx-xx)
+
+  [BUG FIXES]
+
+  * #319 make fortinet return a useful interface name (inphobia)
+
 Version 3.66 (2019-03-24)
 
   [NEW FEATURES]

--- a/lib/SNMP/Info/Layer3/Fortinet.pm
+++ b/lib/SNMP/Info/Layer3/Fortinet.pm
@@ -63,6 +63,29 @@ sub vendor {
     return 'fortinet';
 }
 
+# fortios 5.4 and higher can have empty ifDescr. use ifName (but
+# without the ifAlias fixup that's done in layer3::i_name()) which
+# mimics fortios >5.4
+# copied from an old Layer3.pm which did not have duplicate
+# description fixup
+sub interfaces {
+    my $fortinet = shift;
+    my $partial  = shift;
+
+    my $interfaces   = $fortinet->i_index($partial);
+    my $descriptions = $fortinet->orig_i_name($partial);
+
+    my %interfaces = ();
+    foreach my $iid ( keys %$interfaces ) {
+        my $desc = $descriptions->{$iid};
+        next unless defined $desc;
+
+        $interfaces{$iid} = $desc;
+    }
+
+    return \%interfaces;
+}
+
 sub model {
     my $fortinet = shift;
     my $id = $fortinet->id() || '';
@@ -192,6 +215,14 @@ See documentation in L<SNMP::Info::Layer3/"GLOBALS"> for details.
 
 These are methods that return tables of information in the form of a reference
 to a hash.
+
+=over
+
+=item $fortinet->interfaces();
+
+Returns the map between SNMP Interface Identifier (iid) and C<ifName>.
+
+=back
 
 =head2 Table Methods imported from SNMP::Info::Layer3
 


### PR DESCRIPTION
see fortinet kb FD40872
https://kb.fortinet.com/kb/microsites/search.do?cmd=displayKC&docType=kc&externalId=FD40872&sliceId=1&docTypeID=DT_KCARTICLE_1_1&dialogID=106290224&stateId=1%200%20106288281%27

also fixes missing interface issue due to being unable to map the port
'interfaces - ignoring 54 (no port mapping)'

the missing interface thing requires a closer look, but it might be related to 7d2cf97 & https://sourceforge.net/p/snmp-info/patches/68/
perhaps even #306 