### PR TITLE
fix cdp_port when returned value is exactly 6 chars

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,6 +11,7 @@ Version 3.69 (2019-xx-xx)
 
   * #353 doc fixes: report all required mibs for each module as based on code
   * #353 include fixes: don't include modules already imported from parent classes
+  * #355 fix #252, don't think 6char devices names are mac addresses
 
 Version 3.68 (2019-04-28)
 

--- a/lib/SNMP/Info/CDP.pm
+++ b/lib/SNMP/Info/CDP.pm
@@ -82,7 +82,6 @@ $VERSION = '3.68';
     'cdp_ver'          => \&SNMP::Info::munge_null,
     'cdp_ip'           => \&SNMP::Info::munge_ip,
     'cdp_power'        => \&munge_power,
-
 );
 
 %CDP_CAPABILITIES = (
@@ -222,11 +221,17 @@ sub cdp_port {
 
     my $ch = $cdp->cdp_dev_port($partial) || {};
 
+    # most devices return a string with the interface name here (Port-ID TLV)
+    # see https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/cdp/command/cdp-cr-book/cdp-cr-a1.html
+    # it seems however that some devices report hex encoded mac addresses for this, see
+    # https://github.com/netdisco/snmp-info/issues/252
+    # once these bad devices get known we can figure out workarounds for them
+
     my %cdp_port;
     foreach my $key ( sort keys %$ch ) {
         my $port = $ch->{$key};
         next unless $port;
-        $port = SNMP::Info::munge_mac($port) || SNMP::Info::munge_null($port);
+        $port = SNMP::Info::munge_null($port);
         $cdp_port{$key} = $port;
     }
     return \%cdp_port;
@@ -278,8 +283,8 @@ SNMP::Info::CDP is a subclass of SNMP::Info that provides an object oriented
 interface to CDP information through SNMP.
 
 CDP is a Layer 2 protocol that supplies topology information of devices that
-also speak CDP, mostly switches and routers.  CDP is implemented in Cisco and
-some HP devices.
+also speak CDP, mostly switches and routers.  CDP is implemented by Cisco and
+several other vendors.
 
 Create or use a device subclass that inherits this class.  Do not use
 directly.
@@ -477,9 +482,10 @@ Returns remote platform id
 
 =item $cdp->cdp_port()
 
-Returns remote port ID
+Returns remote Port-ID. Most of the time this is a string with the port name, but this
+is not guaranteed to be so.
 
-(C<cdpDevicePort>)
+(C<cdpCacheDevicePort>)
 
 =item  $cdp->cdp_proto()
 

--- a/xt/lib/Test/SNMP/Info/CDP.pm
+++ b/xt/lib/Test/SNMP/Info/CDP.pm
@@ -29,6 +29,8 @@
 
 package Test::SNMP::Info::CDP;
 
+use strict;
+use warnings;
 use Test::Class::Most parent => 'My::Test::Class';
 
 use SNMP::Info::CDP;
@@ -51,7 +53,7 @@ sub setup : Tests(setup) {
       'cdp_proto' => {'2.1' => 'ip',                   '3.1' => 'chaos'},
       'cdp_capabilities' => {'2.1' => pack("H*", '00000228')},
       'cdp_dev_id'       => {'2.1' => pack("H*", 'ABCD12345678')},
-      'cdp_dev_port'     => {'2.1' => pack("H*", 'ABCD12345678')},
+      'cdp_dev_port'     => {'2.1' => 'My-Port-Name'},
     }
   };
   $test->{info}->cache($cache_data);
@@ -139,18 +141,12 @@ sub cdp_id : Tests(4) {
   cmp_deeply($test->{info}->cdp_id(), {}, q(No data returns empty hash));
 }
 
-sub cdp_port : Tests(4) {
+sub cdp_port : Tests(3) {
   my $test = shift;
 
   can_ok($test->{info}, 'cdp_port');
 
-  my $expected = {'2.1' => 'ab:cd:12:34:56:78'};
-
-  cmp_deeply($test->{info}->cdp_port(),
-    $expected, q(Remote ID packed MAC has expected value));
-
-  $test->{info}{store}{cdp_dev_port} = {'2.1' => 'My-Port-Name'};
-  $expected = {'2.1' => 'My-Port-Name'};
+  my $expected = {'2.1' => 'My-Port-Name'};
 
   cmp_deeply($test->{info}->cdp_port(),
     $expected, q(Remote ID text has expected value));


### PR DESCRIPTION
fix #252 

removes munge_mac from cdp_port as added in 78119d6.

this of course will also unfix the original reason why this was added, since some devices seem to return a hex formatted mac here and we wanted to handle that.  regretfully the original issue had all data anonymized and i found nothing that could point me to just which devices were doing this. so this will be broken again.

device/os specific fixes will be applied when we actually find a misbehaving device.

also fix docs while here