### PR TITLE
Cisco is using codenames for ios-xe > 16.x

### DIFF
--- a/lib/SNMP/Info/CiscoStats.pm
+++ b/lib/SNMP/Info/CiscoStats.pm
@@ -108,6 +108,7 @@ sub os {
     return 'ios-xe'   if ( $descr =~ /Denali/ );
     return 'ios-xe'   if ( $descr =~ /Fuji/ );
     return 'ios-xe'   if ( $descr =~ /Everest/ );
+    return 'ios-xe'   if ( $descr =~ /Gibraltar/ );
     return 'ios-xe'   if ( $descr =~ /IOS-XE/ );
     return 'ios-xr'   if ( $descr =~ /IOS XR/ );
     return 'ios'      if ( $descr =~ /IOS/ );

--- a/lib/SNMP/Info/CiscoStats.pm
+++ b/lib/SNMP/Info/CiscoStats.pm
@@ -105,6 +105,9 @@ sub os {
 
     # order here matters - there are Catalysts that run IOS and have catalyst
     # in their description field, as well as Catalysts that run IOS-XE.
+    return 'ios-xe'   if ( $descr =~ /Denali/ );
+    return 'ios-xe'   if ( $descr =~ /Fuji/ );
+    return 'ios-xe'   if ( $descr =~ /Everest/ );
     return 'ios-xe'   if ( $descr =~ /IOS-XE/ );
     return 'ios-xr'   if ( $descr =~ /IOS XR/ );
     return 'ios'      if ( $descr =~ /IOS/ );


### PR DESCRIPTION
Example SNMP description:
Cisco IOS Software [Everest], Catalyst L3 Switch Software (CAT3K_CAA-UNIVERSALK9-M), Version 16.6.6, RELEASE SOFTWARE (fc1) Technical Support: http://www.cisco.com/techsupport  Copyright (c) 1986-2019 by Cisco Systems, Inc.  Compiled Thu 11-Apr-19 02:24

`return 'ios-xe'   if ( $descr =~ /CAT3K_CAA-UNIVERSAL/ );`
could also work, but I can not exclude false positives if image names are checked.