### PR TITLE
can't reach these returns

### DIFF
--- a/lib/SNMP/Info/RapidCity.pm
+++ b/lib/SNMP/Info/RapidCity.pm
@@ -298,7 +298,6 @@ sub set_i_duplex_admin {
     else {
         return $rapidcity->set_rc_duplex_admin( $duplexes{$duplex}, $iid );
     }
-    return;
 }
 
 sub set_i_speed_admin {
@@ -321,7 +320,6 @@ sub set_i_speed_admin {
     else {
         return $rapidcity->set_rc_speed_admin( $speeds{$speed}, $iid );
     }
-    return;
 }
 
 sub v_index {


### PR DESCRIPTION
ok, this might be nitpicking, but according to how i read the code the return; statements on lines 301 & 324 can never be reached, since the returns on lines 299 & 322 (or any earlier returns in that if block) will make the subroutine always exit in the if block.

https://github.com/netdisco/snmp-info/blob/631f99f97bf8d363c32c646cfbbc02c2b68a5375/lib/SNMP/Info/RapidCity.pm#L280-L325