### PR TITLE
use latest mibs release instead of hardcoding version tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - mkdir ~/netdisco-mibs
   - cd ~/netdisco-mibs
 install:
-  - curl -sL https://api.github.com/repos/netdisco/netdisco-mibs/releases/latest | jq -r '.tarball_url' | xargs curl -sL | tar --strip-components=1 -zxf -
+  - curl -sL https://api.github.com/repos/netdisco/netdisco-mibs/releases/latest | jq -r '.tarball_url' | xargs -n1 curl -sL | tar --strip-components=1 -zxf -
   - cpanm --quiet --notest PkgConfig Test::CChecker Alien::zlib::Static Alien::OpenSSL::Static Alien::SNMP
 before_script:
   - 'cd ${TRAVIS_BUILD_DIR}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - mkdir ~/netdisco-mibs
   - cd ~/netdisco-mibs
 install:
-  - curl -sL https://github.com/netdisco/netdisco-mibs/releases/download/4.018/netdisco-mibs.tar.gz | tar --strip-components=1 -zxf -
+  - curl -sL https://api.github.com/repos/netdisco/netdisco-mibs/releases/latest | jq -r '.tarball_url' | xargs curl -sL | tar --strip-components=1 -zxf -
   - cpanm --quiet --notest PkgConfig Test::CChecker Alien::zlib::Static Alien::OpenSSL::Static Alien::SNMP
 before_script:
   - 'cd ${TRAVIS_BUILD_DIR}'


### PR DESCRIPTION
benefits:
 * don't need to update mibs url for travis
 * uses the same mibs that netdisco-deploy uses, so more inline with actual behaviour

drawbacks:
 * api calls are rate limited to 60calls/ip/hour(unauthenticated) or 5000calls/hour if authenticated. i don't think travis will hit these rate limits.