### PR TITLE
Add initial support for Teltonika RUT9xx routers

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+Version 3.xx (xxxx-xx-xx)
+
+  [NEW FEATURES]
+
+  * Teltonika RUT9XX support
+
 Version 3.70 (2019-10-15)
 
   [NEW FEATURES]

--- a/lib/SNMP/Info.pm
+++ b/lib/SNMP/Info.pm
@@ -1038,6 +1038,12 @@ Subclass for Avaya Secure Routers.
 
 See documentation in L<SNMP::Info::Layer3::Tasman> for details.
 
+=item SNMP::Info::Layer3::Teltonika
+
+Subclass for Teltonika RUT9xx series routers.
+
+See documentation in L<SNMP::Info::Layer3::Teltonika> for details.
+
 =item SNMP::Info::Layer3::Timetra
 
 Alcatel-Lucent SR Class.
@@ -1923,6 +1929,10 @@ sub device_type {
         $objtype = 'SNMP::Info::Layer3::Scalance'
 	    if ( $soid =~ /\.1\.3\.6\.1\.4\.1\.4329\.6\.1\.2/i );
 
+        # Teltonika RUT9xx Series
+        $objtype = 'SNMP::Info::Layer3::Teltonika'
+            if (
+            $desc =~ /\bTeltonika.*RUT9\d{2}\b/);
 
         # Generic device classification based upon sysObjectID
         if (    ( $objtype eq 'SNMP::Info::Layer3' )
@@ -2133,6 +2143,11 @@ sub device_type {
         # it would flip/flop between those
         $objtype = 'SNMP::Info::Layer3::Scalance'
 	    if ( $soid =~ /\.1\.3\.6\.1\.4\.1\.4329\.6\.1\.2/i );
+
+        # Teltonika RUT9xx Series
+        $objtype = 'SNMP::Info::Layer3::Teltonika'
+            if (
+            $desc =~ /\bTeltonika.*RUT9\d{2}\b/);
 
         # Generic device classification based upon sysObjectID
         if ( defined($id) and $objtype eq 'SNMP::Info') {

--- a/lib/SNMP/Info/Layer3/Teltonika.pm
+++ b/lib/SNMP/Info/Layer3/Teltonika.pm
@@ -55,6 +55,7 @@ $VERSION = '3.70';
     'hrSystemUptime' => 'hrSystemUptime',
     'rut_serial'     => '.1.3.6.1.4.1.48690.1.5.0',
     'os_ver'         => 'firmwareVersion',
+    'model'          => 'productCode',
 );
 
 %FUNCS = ( %SNMP::Info::Layer3::FUNCS, );
@@ -72,26 +73,6 @@ sub os {
 sub serial {
     my $info = shift;
     return $info->rut_serial();
-}
-
-sub model {
-    my $info = shift;
-    return $info->productCode();
-}
-
-sub layers {
-    my $info = shift;
-
-    my $layers = $info->SUPER::layers();
-    # Some models or software versions don't report L2 properly
-    # so add L2 capability to the output if the device has bridge ports.
-    my $bports = $info->b_ports();
-
-    if ($bports) {
-        my $l = substr $layers, 6, 1, "1";
-    }
-
-    return $layers;
 }
 
 1;

--- a/lib/SNMP/Info/Layer3/Teltonika.pm
+++ b/lib/SNMP/Info/Layer3/Teltonika.pm
@@ -1,0 +1,196 @@
+# SNMP::Info::Layer3::Teltonika
+#
+# Copyright (c) 2020 Jeroen van Ingen
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the University of California, Santa Cruz nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR # ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+package SNMP::Info::Layer3::Teltonika;
+
+use strict;
+use warnings;
+use Exporter;
+use SNMP::Info::Layer3;
+
+@SNMP::Info::Layer3::Teltonika::ISA       = qw/SNMP::Info::Layer3 Exporter/;
+@SNMP::Info::Layer3::Teltonika::EXPORT_OK = qw//;
+
+our ($VERSION, %GLOBALS, %MIBS, %FUNCS, %MUNGE);
+
+$VERSION = '3.70';
+
+%MIBS = (
+    %SNMP::Info::Layer3::MIBS,
+    'UCD-SNMP-MIB'        => 'versionTag',
+    'NET-SNMP-TC'         => 'netSnmpAliasDomain',
+    'HOST-RESOURCES-MIB'  => 'hrSystem',
+    'TELTONIKA-MIB'       => 'routerName',
+);
+
+%GLOBALS = (
+    %SNMP::Info::Layer3::GLOBALS,
+    'snmpd_vers'     => 'versionTag',
+    'hrSystemUptime' => 'hrSystemUptime',
+    'rut_serial'     => '.1.3.6.1.4.1.48690.1.5.0',
+    'os_ver'         => 'firmwareVersion',
+);
+
+%FUNCS = ( %SNMP::Info::Layer3::FUNCS, );
+
+%MUNGE = ( %SNMP::Info::Layer3::MUNGE, );
+
+sub vendor {
+    return 'teltonika';
+}
+
+sub os {
+    return 'rutos';
+}
+
+sub serial {
+    my $info = shift;
+    return $info->rut_serial();
+}
+
+sub model {
+    my $info = shift;
+    return $info->productCode();
+}
+
+sub layers {
+    my $info = shift;
+
+    my $layers = $info->SUPER::layers();
+    # Some models or software versions don't report L2 properly
+    # so add L2 capability to the output if the device has bridge ports.
+    my $bports = $info->b_ports();
+
+    if ($bports) {
+        my $l = substr $layers, 6, 1, "1";
+    }
+
+    return $layers;
+}
+
+1;
+__END__
+
+=head1 NAME
+
+SNMP::Info::Layer3::Teltonika - SNMP Interface to Teltonika devices
+
+=head1 AUTHORS
+
+Jeroen van Ingen
+initial version based on SNMP::Info::Layer3::PacketFront
+
+=head1 SYNOPSIS
+
+ # Let SNMP::Info determine the correct subclass for you.
+ my $info = new SNMP::Info(
+                          AutoSpecify => 1,
+                          Debug       => 1,
+                          DestHost    => 'myrouter',
+                          Community   => 'public',
+                          Version     => 2
+                        )
+    or die "Can't connect to DestHost.\n";
+
+ my $class      = $info->class();
+ print "SNMP::Info determined this device to fall under subclass : $class\n";
+
+=head1 DESCRIPTION
+
+Subclass for Teltonika devices
+
+=head2 Inherited Classes
+
+=over
+
+=item SNMP::Info::Layer3
+
+=back
+
+=head2 Required MIBs
+
+=over
+
+=item F<UCD-SNMP-MIB>
+
+=item F<NET-SNMP-TC>
+
+=item F<HOST-RESOURCES-MIB>
+
+=item F<TELTONIKA-MIB>
+
+=item Inherited Classes' MIBs
+
+See L<SNMP::Info::Layer3> for its own MIB requirements.
+
+=back
+
+=head1 GLOBALS
+
+These are methods that return scalar value from SNMP
+
+=over
+
+=item $info->vendor()
+
+Returns C<'teltonika'>.
+
+=item $info->os()
+
+Returns C<'rutos'>.
+
+=item $info->os_ver()
+
+Returns the value of C<firmwareVersion>.
+
+=item $info->model()
+
+Returns the value of C<productCode>.
+
+=item $info->serial()
+
+Returns the value of C<serial>.
+
+=back
+
+=head2 Globals imported from SNMP::Info::Layer3
+
+See documentation in L<SNMP::Info::Layer3> for details.
+
+=head1 TABLE ENTRIES
+
+These are methods that return tables of information in the form of a reference
+to a hash.
+
+=head2 Table Methods imported from SNMP::Info::Layer3
+
+See documentation in L<SNMP::Info::Layer3> for details.
+
+
+=cut


### PR DESCRIPTION
Tested with App::Netdisco 2.42.0 and current netdisco-mibs, which contains the MIB for this class.

@ollyg and/or @inphobia care to do a quick review? I haven't done much with SNMP::Info lately, so I may be missing tests or other stuff that's required before merge/release nowadays. Did look at contrib/DEVELOP instructions and related links, but the info there may be outdated.