### PR TITLE
CH: patch H3C broken node-vlan mapping

### DIFF
--- a/lib/SNMP/Info/Layer3/H3C.pm
+++ b/lib/SNMP/Info/Layer3/H3C.pm
@@ -136,6 +136,16 @@ sub i_ignore {
 
 sub agg_ports { return agg_ports_lag(@_) }
 
+# CH: overwrite and always return empty mapping for qb_fdb_index
+# see https://github.com/netdisco/snmp-info/issues/218
+# if no fdb->vlan mapping is available the fdb is assumed to be the vlan
+# which is ok for h3c
+# otherwise h3c will deliver a broken vlan mapping and nodes will jump
+# other all vlans
+sub qb_fdb_index {
+    return {};
+}
+
 1;
 __END__
 

--- a/lib/SNMP/Info/Layer3/H3C.pm
+++ b/lib/SNMP/Info/Layer3/H3C.pm
@@ -231,6 +231,11 @@ Returns the OS extracted from C<sysDescr>.
 Returns the software version. Either C<entPhysicalSoftwareRev.2> or extracted from
 C<sysDescr>.
 
+=item $h3c->qb_fdb_index()
+
+overwritten to always return empty hash as implementation on 
+h3c is broken.
+
 =back
 
 =head2 Globals imported from SNMP::Info::Layer3


### PR DESCRIPTION
H3C (and newer hewlett packard switches) have an incomplete/broken node to vlan mapping. 
see #218 (https://github.com/netdisco/snmp-info/issues/218)

--+  qb_fw_vlan

qb_fw_vlan is called to figure out in which vlan a mac is located.

fetch qb_fw_port. This is a hash

  fdb_id.mac => fdb_port

for each key split of fdb_id

try to look it up in qb_fdb_ids to translate it to vlan
otherwise use it directly as vlan.

--+ qb_fw_port

qb_fw_port fetchs snmp dot1qTpFdbPort, oid 1.3.6.1.2.1.17.7.1.2.2.1.2

This snmp table returns

  fdb_id.mac => fdb_port

as an example data fetched from a HP switch (Layer2::HP)

  SNMPv2-SMI::mib-2.17.7.1.2.2.1.2.3.52.20.95.80.231.59 = INTEGER: 9

fdb_id: 3
mac: 34:14:5f:50:e7:3b
fdb_port: 9
and an expample for a H3C (Layer3::H3C)

  SNMPv2-SMI::mib-2.17.7.1.2.2.1.2.1.0.17.17.117.83.217 = INTEGER: 891

fdb_id: 1
mac: 0:11:11:75:53:d9
fdb_port: 891

snmp looks got. Verified with netdisco

/opt/netdisco/bin/netdisco-do show -d <SWITCH> -e Layer3::H3C::qb_fw_port
/opt/netdisco/bin/netdisco-do show -d <SWITCH> -e Layer2::HP::qb_fw_port

result looks good.

--+ qb_fdb_index

qb_fdb_index fetches snmp dot1qVlanFdbId which is oid 1.3.6.1.2.1.17.7.1.4.2.1.3

This snmp table returns

  timestamp.vlan => fdb_id

netdisco will strip the timestamp and build a hash

  fdb_id => vlan

for a HP switch i get snmp data

  SNMPv2-SMI::mib-2.17.7.1.4.2.1.3.0.64 = Gauge32: 6

vlan: 64
fdb_id: 6
for a H3C i get

  SNMPv2-SMI::mib-2.17.7.1.4.2.1.3.3330.64 = Gauge32: 1

vlan: 64
fdb_id: 1

and there are the issues.

not all vlans are listed
every line has fdb_id 1
as in all H3C switches i checked, the fdb_id is equal to the vlan i patched out
qb_fdb_index to return an empty hash.