### PR TITLE
ignore .vscode directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ _build
 blib
 cover_db
 .idea
+.vscode


### PR DESCRIPTION
vs code with wsl2 remoting actually works decently. ignore the .vscode dir

wiki entry coming later