### PR TITLE
Support PVID (vlan) change on Arista

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+Version 3.xx (TBD)
+
+  [NEW FEATURES]
+
+  * Support changing PVID on Arista switches (#429)
+
 Version 3.73 (2021-06-28)
 
   [BUG FIXES]

--- a/lib/SNMP/Info/Layer3/Arista.pm
+++ b/lib/SNMP/Info/Layer3/Arista.pm
@@ -128,6 +128,11 @@ sub lldp_if {
     return $lldp_if;
 }
 
+sub set_i_vlan {
+    my ($arista, $vlan, $iid) = @_;
+    return $arista->set_qb_i_vlan($vlan, $iid);
+}
+
 sub agg_ports { return agg_ports_ifstack(@_) }
 
 1;
@@ -257,5 +262,18 @@ See documentation in L<SNMP::Info::Layer3/"TABLE METHODS"> for details.
 =head2 Table Methods imported from SNMP::Info::MAU
 
 See documentation in L<SNMP::Info::MAU/"TABLE METHODS"> for details.
+
+=head1 SET METHODS
+
+These are methods that provide SNMP set functionality for overridden methods
+or provide a simpler interface to complex set operations.  See
+L<SNMP::Info/"SETTING DATA VIA SNMP"> for general information on set
+operations.
+
+=over
+
+=item set_i_vlan()
+
+=back
 
 =cut


### PR DESCRIPTION
Support changing untagged VLAN (PVID) on Arista access ports. Patch needs review wrt documentation, tests etc.