### PR TITLE
trapeze and nws deep recursion fix

### DIFF
--- a/lib/SNMP/Info/Layer2/NWSS2300.pm
+++ b/lib/SNMP/Info/Layer2/NWSS2300.pm
@@ -53,9 +53,9 @@ $VERSION = '3.80';
 
 %GLOBALS = (
     %SNMP::Info::Layer2::GLOBALS,
-    'os_ver' => 'ntwsVersionString',
-    'serial' => 'ntwsSerialNumber',
-    'mac'    => 'dot1dBaseBridgeAddress',
+    'os_ver'     => 'ntwsVersionString',
+    'nws_serial' => 'ntwsSerialNumber',
+    'mac'        => 'dot1dBaseBridgeAddress',
 );
 
 %FUNCS = (
@@ -137,6 +137,14 @@ sub os {
 
 sub vendor {
     return 'avaya';
+}
+
+sub serial {
+    my $nwss2300 = shift;
+    my $ser = $nwss2300->ntwsSerialNumber();
+#    my $ser = $nwss2300->nws_serial();
+
+    return $ser;
 }
 
 sub model {

--- a/lib/SNMP/Info/Layer2/NWSS2300.pm
+++ b/lib/SNMP/Info/Layer2/NWSS2300.pm
@@ -662,7 +662,7 @@ sub e_serial {
     my %e_serial;
 
     # Chassis
-    $e_serial{1} = $nwss2300->serial();
+    $e_serial{1} = $nwss2300->serial()  || '';
 
     # APs
     foreach my $iid ( keys %$ap_serial ) {

--- a/lib/SNMP/Info/Layer2/Trapeze.pm
+++ b/lib/SNMP/Info/Layer2/Trapeze.pm
@@ -53,9 +53,9 @@ $VERSION = '3.80';
 
 %GLOBALS = (
     %SNMP::Info::Layer2::GLOBALS,
-    'os_ver' => 'trpzVersionString',
-    'serial' => 'trpzSerialNumber',
-    'mac'    => 'dot1dBaseBridgeAddress',
+    'os_ver'    => 'trpzVersionString',
+    'tr_serial' => 'trpzSerialNumber',
+    'mac'       => 'dot1dBaseBridgeAddress',
 );
 
 %FUNCS = (
@@ -136,6 +136,14 @@ sub os {
 
 sub vendor {
     return 'juniper';
+}
+
+sub serial {
+    my $trapeze = shift;
+    my $ser = $trapeze->trpzSerialNumber();
+#    my $ser = $trapeze->tr_serial();
+
+    return $ser;
 }
 
 sub model {
@@ -653,7 +661,7 @@ sub e_serial {
     my %e_serial;
 
     # Chassis
-    $e_serial{1} = $trapeze->serial();
+    $e_serial{1} = $trapeze->serial() || '';
 
     # APs
     foreach my $iid ( keys %$ap_serial ) {

--- a/xt/lib/Test/SNMP/Info/Layer2/NWSS2300.pm
+++ b/xt/lib/Test/SNMP/Info/Layer2/NWSS2300.pm
@@ -51,6 +51,9 @@ sub setup : Tests(setup) {
     '_description' =>
       'Nortel Wireless Security Switch 2380, 7.0.13.3 REL',
 
+    # NTWS-BASIC-MIB
+    '_ntwsSerialNumber' => 'STP1E4013Z',
+
     # NTWS-REGISTRATION-DEVICES-MIB::ntwsSwitch2380
     '_id'                   => '.1.3.6.1.4.1.45.6.1.3.1.3',
     'store'                 => {},
@@ -70,6 +73,17 @@ sub vendor : Tests(2) {
 
   can_ok($test->{info}, 'vendor');
   is($test->{info}->vendor(), 'avaya', q(Vendor returns 'avaya'));
+}
+
+sub serial : Tests(3) {
+  my $test = shift;
+
+  can_ok($test->{info}, 'serial');
+  is($test->{info}->serial(), 'STP1E4013Z', q(Serial is expected value));
+
+  $test->{info}->clear_cache();
+  is($test->{info}->serial(), undef,
+    q(No serial returns undef));
 }
 
 1;

--- a/xt/lib/Test/SNMP/Info/Layer2/Trapeze.pm
+++ b/xt/lib/Test/SNMP/Info/Layer2/Trapeze.pm
@@ -51,6 +51,9 @@ sub setup : Tests(setup) {
     '_description' =>
       'Juniper Networks, Inc WLC880R 7.5.1.6 REL',
 
+    # TRAPEZE-NETWORKS-BASIC-MIB
+    '_trpzSerialNumber' => '0882200159',
+
     # TRAPEZE-NETWORKS-REGISTRATION-DEVICES-MIB::wirelessLANController880R
     '_id'                   => '.1.3.6.1.4.1.14525.3.3.1',
     'store'                 => {},
@@ -77,6 +80,17 @@ sub vendor : Tests(2) {
 
   can_ok($test->{info}, 'vendor');
   is($test->{info}->vendor(), 'juniper', q(Vendor returns 'juniper'));
+}
+
+sub serial : Tests(3) {
+  my $test = shift;
+
+  can_ok($test->{info}, 'serial');
+  is($test->{info}->serial(), '0882200159', q(Serial is expected value));
+
+  $test->{info}->clear_cache();
+  is($test->{info}->serial(), undef,
+    q(No serial returns undef));
 }
 
 1;


### PR DESCRIPTION
#441 
#402 

not real pretty but i got lost in the autoloader labyrinth. also no idea if this works since i don't have any snmpdumps of these devices 

issue is simpel to reproduce: just run the updates tests without updating the layer2::trapeze/nwss2300
(serials in the tests were found with a google image search)

layer3::arube seems to be a better template to redesign these modules with