### PR TITLE
Add SNMPv3 parameters to example code

### DIFF
--- a/lib/SNMP/Info.pm
+++ b/lib/SNMP/Info.pm
@@ -64,6 +64,14 @@ list any missing functionality (such as neighbor discovery tables).
                             DestHost    => 'router',
                             Community   => 'public',
                             Version     => 2
+                            # Parameter reference for SNMPv3
+                            # Version   => 3
+                            # SecLevel  => 'authPriv', # authPriv|authNoPriv|noAuthNoPriv
+                            # SecName   => 'myuser',
+                            # AuthProto => 'MD5',      # MD5|SHA
+                            # AuthPass  => 'authp4ss',
+                            # PrivProto => 'DES',      # DES|AES
+                            # PrivPass  => 'pr1vp4ss',
                           ) or die "Can't connect to device.\n";
 
  my $err = $info->error();


### PR DESCRIPTION
How about we add the most commonly used SNMPv3 parameters and their expected case/spelling to the doc? It just took me surprisingly long to get the Hello World code going.