### PR TITLE
Initial commit of PortAccessEntity/IEEE8021-PAE-MIB module

### DIFF
--- a/lib/SNMP/Info.pm
+++ b/lib/SNMP/Info.pm
@@ -435,6 +435,12 @@ F<S5-AGENT-MIB>, F<S5-CHASSIS-MIB>.
 
 See documentation in L<SNMP::Info::NortelStack> for details.
 
+=item SNMP::Info::PortAccessEntity
+
+F<IEEE8021-PAE-MIB>
+
+See documentation in L<SNMP::Info::PortAccessEntity> for details.
+
 =item SNMP::Info::PowerEthernet
 
 F<POWER-ETHERNET-MIB>

--- a/lib/SNMP/Info/Layer2.pm
+++ b/lib/SNMP/Info/Layer2.pm
@@ -37,12 +37,21 @@ use Exporter;
 use SNMP::Info;
 use SNMP::Info::Bridge;
 use SNMP::Info::Entity;
+use SNMP::Info::PortAccessEntity;
 use SNMP::Info::PowerEthernet;
 use SNMP::Info::LLDP;
 use SNMP::Info::DocsisHE;
 
-@SNMP::Info::Layer2::ISA
-    = qw/SNMP::Info SNMP::Info::Bridge SNMP::Info::Entity SNMP::Info::PowerEthernet SNMP::Info::LLDP SNMP::Info::DocsisHE Exporter/;
+@SNMP::Info::Layer2::ISA = qw/
+        SNMP::Info SNMP::Info::Bridge
+        SNMP::Info::Entity
+        SNMP::Info::PowerEthernet
+        SNMP::Info::LLDP
+        SNMP::Info::DocsisHE
+        SNMP::Info::PortAccessEntity
+        Exporter
+/;
+
 @SNMP::Info::Layer2::EXPORT_OK = qw//;
 
 our ($VERSION, %GLOBALS, %MIBS, %FUNCS, %PORTSTAT, %MUNGE);
@@ -53,6 +62,7 @@ $VERSION = '3.85';
     %SNMP::Info::MIBS,         %SNMP::Info::Bridge::MIBS,
     %SNMP::Info::Entity::MIBS, %SNMP::Info::PowerEthernet::MIBS,
     %SNMP::Info::LLDP::MIBS,   %SNMP::Info::DocsisHE::MIBS,
+    %SNMP::Info::PortAccessEntity::MIBS
 );
 
 %GLOBALS = (
@@ -62,6 +72,7 @@ $VERSION = '3.85';
     %SNMP::Info::Entity::GLOBALS,
     %SNMP::Info::PowerEthernet::GLOBALS,
     %SNMP::Info::LLDP::GLOBALS,
+    %SNMP::Info::PortAccessEntity::GLOBALS,
     'serial1' =>
         '.1.3.6.1.4.1.9.3.6.3.0',    # OLD-CISCO-CHASSIS-MIB::chassisId.0
 );
@@ -70,6 +81,7 @@ $VERSION = '3.85';
     %SNMP::Info::FUNCS,         %SNMP::Info::Bridge::FUNCS,
     %SNMP::Info::Entity::FUNCS, %SNMP::Info::PowerEthernet::FUNCS,
     %SNMP::Info::LLDP::FUNCS,   %SNMP::Info::DocsisHE::FUNCS,
+    %SNMP::Info::PortAccessEntity::FUNCS
 );
 
 %MUNGE = (
@@ -81,6 +93,7 @@ $VERSION = '3.85';
     %SNMP::Info::Entity::MUNGE,
     %SNMP::Info::PowerEthernet::MUNGE,
     %SNMP::Info::LLDP::MUNGE,
+    %SNMP::Info::PortAccessEntity::MUNGE,
 );
 
 # Method OverRides
@@ -236,6 +249,8 @@ after determining a more specific class using the method above.
 
 =item SNMP::Info::PowerEthernet
 
+=item SNMP::Info::PortAccessEntity
+
 =back
 
 =head2 Required MIBs
@@ -293,6 +308,10 @@ See documentation in L<SNMP::Info::Entity/"GLOBALS"> for details.
 
 See documentation in L<SNMP::Info::LLDP/"GLOBALS"> for details.
 
+=head2 Globals imported from SNMP::Info::PortAccessEntity
+
+See documentation in L<SNMP::Info::PortAccessEntity/"GLOBALS"> for details.
+
 =head1 TABLE METHODS
 
 These are methods that return tables of information in the form of a reference
@@ -326,5 +345,9 @@ See documentation in L<SNMP::Info::Entity/"TABLE METHODS"> for details.
 =head2 Table Methods imported from SNMP::Info::LLDP
 
 See documentation in L<SNMP::Info::LLDP/"TABLE METHODS"> for details.
+
+=head2 Table Methods imported from SNMP::Info::PortAccessEntity
+
+See documentation in L<SNMP::Info::PortAccessEntity/"TABLE METHODS"> for details.
 
 =cut

--- a/lib/SNMP/Info/Layer3/CiscoSwitch.pm
+++ b/lib/SNMP/Info/Layer3/CiscoSwitch.pm
@@ -35,6 +35,7 @@ use Exporter;
 use SNMP::Info::CiscoAgg;
 use SNMP::Info::CiscoPortSecurity;
 use SNMP::Info::Layer3::Cisco;
+use SNMP::Info::PortAccessEntity;
 
 our ($VERSION, %GLOBALS, %MIBS, %FUNCS, %MUNGE);
 
@@ -42,6 +43,7 @@ our ($VERSION, %GLOBALS, %MIBS, %FUNCS, %MUNGE);
     SNMP::Info::CiscoAgg
     SNMP::Info::CiscoPortSecurity
     SNMP::Info::Layer3::Cisco
+    SNMP::Info::PortAccessEntity
     Exporter
 /;
 
@@ -53,24 +55,28 @@ $VERSION = '3.85';
     %SNMP::Info::Layer3::Cisco::MIBS,
     %SNMP::Info::CiscoPortSecurity::MIBS,
     %SNMP::Info::CiscoAgg::MIBS,
+    %SNMP::Info::PortAccessEntity::MIBS,
 );
 
 %GLOBALS = (
     %SNMP::Info::Layer3::Cisco::GLOBALS,
     %SNMP::Info::CiscoPortSecurity::GLOBALS,
     %SNMP::Info::CiscoAgg::GLOBALS,
+    %SNMP::Info::PortAccessEntity::GLOBALS,
 );
 
 %FUNCS = (
     %SNMP::Info::Layer3::Cisco::FUNCS,
     %SNMP::Info::CiscoPortSecurity::FUNCS,
     %SNMP::Info::CiscoAgg::FUNCS,
+    %SNMP::Info::PortAccessEntity::FUNCS,
 );
 
 %MUNGE = (
     %SNMP::Info::Layer3::Cisco::MUNGE,
     %SNMP::Info::CiscoPortSecurity::MUNGE,
     %SNMP::Info::CiscoAgg::MUNGE,
+    %SNMP::Info::PortAccessEntity::MUNGE,
 );
 
 sub cisco_comm_indexing { return 1; }

--- a/lib/SNMP/Info/PortAccessEntity.pm
+++ b/lib/SNMP/Info/PortAccessEntity.pm
@@ -1,0 +1,179 @@
+# SNMP::Info::PortAccessEntity
+#
+# Copyright (c) 2022 Christian Ramseyer
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the University of California, Santa Cruz nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR # ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+package SNMP::Info::PortAccessEntity;
+
+use strict;
+use warnings;
+use Exporter;
+use SNMP::Info;
+use Regexp::Common qw /net/;
+
+@SNMP::Info::PortAccessEntity::ISA       = qw/SNMP::Info Exporter/;
+@SNMP::Info::PortAccessEntity::EXPORT_OK = qw//;
+
+our ($VERSION, %MIBS, %FUNCS, %GLOBALS, %MUNGE);
+
+$VERSION = '3.85';
+
+%MIBS = ( 'IEEE8021-PAE-MIB' => 'dot1xPaeSystemAuthControl' );
+
+%GLOBALS = ();
+
+%FUNCS = (
+
+    # dot1xPaeSystem
+    'pae_control'  => 'dot1xPaeSystemAuthControl',
+
+    # dot1xAuthConfigEntry
+    'pae_authconfig_state'         => 'dot1xAuthPaeState', # disconnected|authenticated
+    'pae_authconfig_port_status'   => 'dot1xAuthAuthControlledPortStatus', #(un)authorized
+
+    # dot1xAuthSessionStatsTable
+    'pae_authsess_user'  => 'dot1xAuthSessionUserName',
+
+);
+
+%MUNGE = ();
+
+# try to figure out whether the method is mac address bypass (mab) or dot1x. At least on Cisco,
+# having a MAC address as the "UserName" seems to point at mab.
+sub pae_authsess_mab {
+    my $this    = shift;
+
+    my $u = $this->pae_authsess_user();
+
+    my $mab = {};
+    foreach my $i ( keys %$u ) {
+	    if ($u->{$i} =~ /$RE{net}{MAC}{hex}{-sep=>'[-:]'}/ ) {
+	        $mab->{$i} = "mab" ;
+	    }
+    }
+    return $mab;
+}
+
+
+1;
+
+__END__
+
+=head1 NAME
+
+SNMP::Info::PortAccessEntity - SNMP Interface to data stored in
+F<IEEE8021-PAE-MIB>.
+
+=head1 AUTHOR
+
+Christian Ramseyer
+
+=head1 SYNOPSIS
+
+ # Let SNMP::Info determine the correct subclass for you.
+ my $pae = new SNMP::Info(
+                          AutoSpecify => 1,
+                          Debug       => 1,
+                          DestHost    => 'myswitch',
+                          Community   => 'public',
+                          Version     => 2
+                        )
+    or die "Can't connect to DestHost.\n";
+
+ my $class      = $pae->class();
+ print "SNMP::Info determined this device to fall under subclass : $class\n";
+
+=head1 DESCRIPTION
+
+F<IEEE8021-PAE-MIB> is used to describe Port Access Entities, aka NAC/dot1x features.
+
+Create or use a device subclass that inherit this class.  Do not use directly.
+
+For debugging purposes you can call this class directly as you would
+SNMP::Info
+
+ my $pae = new SNMP::Info::PortAccessEntity (...);
+
+=head2 Inherited Classes
+
+none.
+
+=head2 Required MIBs
+
+=over
+
+=item F<IEEE8021-PAE-MIB>
+
+=back
+
+=head1 GLOBALS
+
+none.
+
+=head1 METHODS
+
+=over
+
+=item $pae->pae_control()
+
+The administrative enable/disable state for Port Access Control in a System.
+Possible values are enabled and disabled.
+
+C<dot1xPaeSystemAuthControl>
+
+=back
+
+=head1 TABLE METHODS
+
+These are methods that return tables of information in the form of a reference
+to a hash.
+
+=over
+
+=item $pae->pae_authconfig_state()
+
+Authentication state: is the port authenticated, disconnected, etc. 
+
+C<dot1xAuthPaeState>
+
+=item $pae->pae_authconfig_port_status()
+
+Controlled Port status parameter for the Port: can only be authorized or unauthorized
+
+C<dot1xAuthAuthControlledPortStatus>
+
+=item $pae->pae_authsess_user()
+
+The User-Name representing the identity of the Supplicant PAE. This can be a pretty
+arbitrary string besides an actual username, e.g. a MAC address for MAB or a hostname
+for dot1x.
+
+C<dot1xAuthSessionUserName>
+
+=back
+
+=cut

--- a/lib/SNMP/Info/PortAccessEntity.pm
+++ b/lib/SNMP/Info/PortAccessEntity.pm
@@ -44,20 +44,18 @@ $VERSION = '3.85';
 
 %MIBS = ( 'IEEE8021-PAE-MIB' => 'dot1xPaeSystemAuthControl' );
 
-%GLOBALS = ();
-
-%FUNCS = (
-
+%GLOBALS = (
     # dot1xPaeSystem
     'pae_control'  => 'dot1xPaeSystemAuthControl',
+);
 
+%FUNCS = (
     # dot1xAuthConfigEntry
     'pae_authconfig_state'         => 'dot1xAuthPaeState', # disconnected|authenticated
     'pae_authconfig_port_status'   => 'dot1xAuthAuthControlledPortStatus', #(un)authorized
 
     # dot1xAuthSessionStatsTable
     'pae_authsess_user'  => 'dot1xAuthSessionUserName',
-
 );
 
 %MUNGE = ();
@@ -131,10 +129,6 @@ none.
 =back
 
 =head1 GLOBALS
-
-none.
-
-=head1 METHODS
 
 =over
 

--- a/lib/SNMP/Info/PortAccessEntity.pm
+++ b/lib/SNMP/Info/PortAccessEntity.pm
@@ -174,6 +174,11 @@ for dot1x.
 
 C<dot1xAuthSessionUserName>
 
+=item $pae->pae_authsess_mab()
+
+Helper method, guess if this a mac address bypass port: contains the string "mab" for indexes where the 
+pae_authsess_user looks like a MAC address.
+
 =back
 
 =cut


### PR DESCRIPTION
This should provide some rudimentary coverage of the most important IEEE8021-PAE-MIB attributes. Not quite sure on which device classes exactly to add this, for my test cases it only seemed to be needed on Layer3/CiscoSwitch.pm.

I have not spent much time with SNMP::Info before today so please be gentle :)