### PR TITLE
Update for Cisco 9xxx Serie

### DIFF
--- a/lib/SNMP/Info/CiscoStats.pm
+++ b/lib/SNMP/Info/CiscoStats.pm
@@ -110,6 +110,10 @@ sub os {
     return 'ios-xe'   if ( $descr =~ /Everest/ );
     return 'ios-xe'   if ( $descr =~ /Gibraltar/ );
     return 'ios-xe'   if ( $descr =~ /Amsterdam/ );
+    return 'ios-xe'   if ( $descr =~ /Bengaluru/ );
+    return 'ios-xe'   if ( $descr =~ /Cupertino/ );
+    return 'ios-xe'   if ( $descr =~ /Dublin/ );
+    return 'ios-xe'   if ( $descr =~ /IOSXE/ );
     return 'ios-xe'   if ( $descr =~ /IOS-XE/ );
     return 'ios-xr'   if ( $descr =~ /IOS XR/ );
     return 'ios'      if ( $descr =~ /IOS/ );


### PR DESCRIPTION
New codenames for version 17.x: https://www.cisco.com/c/en/us/support/ios-nx-os-software/ios-xe-17/series.html

also added IOSXE for Cisco Catalyst 9200 & 9300 Series:

netdisco-do show -e description -d C93XX.switch
Cisco IOS Software [Bengaluru], Catalyst L3 Switch Software (CAT9K_IOSXE), Version 17.5.1, RELEASE SOFTWARE (fc3) Technical Support: http://www.cisco.com/techsupport Copyright (c) 1986-2021 by Cisco Systems, Inc.
Compiled Wed 31-Mar-21 01:46 by mcpre

netdisco-do show -e description -d C92XX.switch
Cisco IOS Software [Amsterdam], Catalyst L3 Switch Software (CAT9K_LITE_IOSXE), Version 17.3.5, RELEASE SOFTWARE (fc2) Technical Support: http://www.cisco.com/techsupport Copyright (c) 1986-2022 by Cisco Systems, Inc.
Compiled Wed 09-Feb-22 09:28 by mc