### PR TITLE
Update SNMP::Info::Layer7::Neoteris

### DIFF
--- a/lib/SNMP/Info/Layer7/Neoteris.pm
+++ b/lib/SNMP/Info/Layer7/Neoteris.pm
@@ -48,6 +48,7 @@ $VERSION = '3.972002';
 
 %GLOBALS = (
     %SNMP::Info::Layer7::GLOBALS,
+    'product_name' => 'productName',
     'pulse_os_ver' => 'productVersion',
     'cpu'          => 'iveCpuUtil',
 );
@@ -82,9 +83,14 @@ sub serial {
 sub model {
     my $neoteris = shift;
     my $id       = $neoteris->id();
-    my $model    = &SNMP::translateObj($id);
+    my $product_name = $neoteris->product_name();
 
-    $model =~ s/^ive//i;
+    my $model    = &SNMP::translateObj($id);
+    if ($product_name =~ /^(Ivanti|Pulse) Connect Secure,(\S+)/) {
+        $model = $2;
+    } else {
+        $model =~ s/^ive//i;
+    }
 
     return $model;
 }


### PR DESCRIPTION
In some version of Ivanti Secure Gateway, the sysObjectID is not set to the model version (seen with a Ivanti Secure Gateway as VM on vCenter)

To retrieve the correct version, we can check the OID `PULSESECURE-PSG-MIB::productName`

More information concerning this part here:
https://forums.ivanti.com/s/article/KB44533?language=en_US

By example, in my case, i have the following output:
```
$ snmpwalk 172.31.13.41 SNMPv2-MIB::sysObjectID
SNMPv2-MIB::sysObjectID.0 = OID: PULSESECURE-PSG-MIB::pulsesecure-gateway.0.0.0
$ snmpwalk 172.31.13.41 PULSESECURE-PSG-MIB::productName
PULSESECURE-PSG-MIB::productName.0 = STRING: "Ivanti Connect Secure,ISA6000-V(VMware)
"
```