### PR TITLE
fix warning: Use of uninitialized value in gethostbyname

### DIFF
--- a/lib/SNMP/Info/Layer3/Scalance.pm
+++ b/lib/SNMP/Info/Layer3/Scalance.pm
@@ -153,10 +153,12 @@ sub lldp_ip {
     my %result;
     my $remotes = $scalance->lldp_rem_sysname();
     foreach my $port ( keys %$remotes) {
-	my $ip = gethostbyname($remotes->{$port});
-	if ($ip) {
-	    $result{$port} = inet_ntoa($ip);
-	}
+        if (defined $remotes->{$port}) {
+            my $ip = gethostbyname($remotes->{$port});
+            if ($ip) {
+                $result{$port} = inet_ntoa($ip);
+            }
+        }
     }
     return \%result
 };


### PR DESCRIPTION
Calling `netdisco-do discover` on a _Siemens Scalance_ might show multiple warnings:
```
Use of uninitialized value in gethostbyname at /home/netdisco/perl5/lib/perl5/SNMP/Info/Layer3/Scalance.pm line 156.
```
My pull-request calls `gethostbyname()` only if the argument is defined to prevent this warning.