### PR TITLE
Improve Huawei os, os_ver

### DIFF
--- a/xt/lib/Test/SNMP/Info/Layer3/Huawei.pm
+++ b/xt/lib/Test/SNMP/Info/Layer3/Huawei.pm
@@ -159,6 +159,27 @@ sub os_ver_with_patch : Tests(2) {
   );
 }
 
+sub os_patch : Tests {
+  my $test = shift;
+
+  can_ok($test->{info}, '_os_patch');
+
+  # more explanation is in _os_patch
+  my %cases = (
+    'V600R023HP1501'        => 'HP1501',
+    'V200R011SPC102'        => 'SPC102',
+    'V200R011SPH033'        => 'SPH033',
+    'V200R022C00SPC100B189' => 'B189',
+    'V200R023CO0SPH180'     => 'SPH180',
+  );
+
+  while (my ($input, $expected) = each %cases) {
+    $test->{info}{store}{hw_patch_version} = { '1' => $input };
+    is( $test->{info}->_os_patch(), $expected, "extracting patch from $input" );
+  }
+}
+
+
 sub os_ver : Tests(9) {
   my $test = shift;
 


### PR DESCRIPTION
Huawei os and os_ver in inventory currently has these messy variants:

    os             | os_ver
    huawei         | Version 5.170 V200R011C10SPC600
    VRP            | 1.23.1.1 V600R023C10SPC500
    VRP            | V200R023C00SPC100





This PR tries making this more uniform, current ideas are 

 * either properly call os YunShan OS and VRP, or call both of them huawei
 * use primarily the detailled build like V200R023C00SPC100 
 * add the patch level from HUAWEI-SYS-MAN-MIB::hwPatchFileVersion
   * maybe directly append the hotfix/patch/collection like V600R023C10SPC500 SPC033
   * or somewhere else like in a custom field or added to the descr?

 
e.g.

    os         | os_ver
    VRP        | V200R011C10SPC600
    YunShan OS | V600R023C10SPC500

or 

    os         | os_ver
    VRP        | V200R011C10SPC600 HP151
    YunShan OS | V600R023C10SPC500 SPC033


before/after in Netdisco:


    netdisco=> select 'new', ip,  snmp_class, vendor, os, os_ver from device where ip in ('10.0.0.21', '10.0.0.10');
    
     ?column? |    ip           |         snmp_class         | vendor |     os     |          os_ver
    ----------+-----------------+----------------------------+--------+------------+--------------------------
     new      | 10.0.0.21       | SNMP::Info::Layer3::Huawei | huawei | VRP        | V200R011C10SPC600 SPH033
     new      | 10.0.0.10       | SNMP::Info::Layer3::Huawei | huawei | YunShan OS | V600R023C10SPC500 HP1501

    
    netdisco=> select 'old', ip,  snmp_class, vendor, os, os_ver from device where ip in ('192.168.100.111', '192.168.100.222');
     ?column? |       ip        |         snmp_class         | vendor |   os   |             os_ver
    ----------+-----------------+----------------------------+--------+--------+---------------------------------
     old      | 192.168.100.111 | SNMP::Info::Layer3::Huawei | huawei | VRP    | Version 5.170 V200R011C10SPC600
     old      | 192.168.100.222 | SNMP::Info::Layer3::Huawei | huawei | huawei | 1.23.1.1 V600R023C10SPC500


I like the draft shown here with the attached patch number, and generally in the IRC people have been in favor of going broadly into that direction. But since many people have worked on Huawei.pm over the years, I'll leave this here for a while first for inputs/comments/complaints.



